### PR TITLE
Add basic serialisation / deserialisation benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ criterion = "0.3.5"
 [[bench]]
 name = "cache"
 harness = false
+
+[[bench]]
+name = "serialise_deserialise"
+harness = false

--- a/benches/serialise_deserialise.rs
+++ b/benches/serialise_deserialise.rs
@@ -1,0 +1,157 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+
+use resolved::protocol::wire_types::*;
+
+#[allow(non_snake_case)]
+fn bench__question(c: &mut Criterion) {
+    let message = Message::from_question(
+        1234,
+        Question {
+            name: DomainName::from_dotted_string("www.example.com").unwrap(),
+            qtype: QueryType::Record(RecordType::A),
+            qclass: QueryClass::Record(RecordClass::IN),
+        },
+    );
+
+    c.bench_function("serialise/question", |b| {
+        b.iter_batched(
+            || message.clone(),
+            |message| message.to_octets(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let serialised = message.clone().to_octets();
+    c.bench_function("deserialise/question", |b| {
+        b.iter(|| Message::from_octets(black_box(&serialised)))
+    });
+}
+
+#[allow(non_snake_case)]
+fn bench__answer__small(c: &mut Criterion) {
+    let mut message = Message::from_question(
+        1234,
+        Question {
+            name: DomainName::from_dotted_string("www.example.com").unwrap(),
+            qtype: QueryType::Record(RecordType::A),
+            qclass: QueryClass::Record(RecordClass::IN),
+        },
+    )
+    .make_response();
+
+    message.header.ancount = 1;
+    message.answers = vec![a_record("www.example.com", vec![1, 1, 1, 1])];
+
+    c.bench_function("serialise/answer/small", |b| {
+        b.iter_batched(
+            || message.clone(),
+            |message| message.to_octets(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let serialised = message.clone().to_octets();
+    c.bench_function("deserialise/answer/small", |b| {
+        b.iter(|| Message::from_octets(black_box(&serialised)))
+    });
+}
+
+#[allow(non_snake_case)]
+fn bench__answer__big(c: &mut Criterion) {
+    let mut message = Message::from_question(
+        1234,
+        Question {
+            name: DomainName::from_dotted_string("www.example.com").unwrap(),
+            qtype: QueryType::Record(RecordType::A),
+            qclass: QueryClass::Record(RecordClass::IN),
+        },
+    )
+    .make_response();
+
+    let count = 128;
+
+    message.header.ancount = count;
+    message.header.nscount = count;
+    message.header.arcount = count;
+
+    for i in 0..count {
+        message.answers.push(cname_record(
+            "www.example.com",
+            &format!("www.cname-target-{:?}.example.com", i),
+        ));
+    }
+    for i in 0..count {
+        message.authority.push(ns_record(
+            &format!("cname-target-{:?}.example.com", i),
+            &format!("ns-{:?}.example.com", i),
+        ));
+    }
+    for i in 0..count {
+        message.additional.push(a_record(
+            &format!("ns-{:?}.example.com", i),
+            vec![1, 1, 1, 1],
+        ));
+    }
+
+    c.bench_function("serialise/answer/big", |b| {
+        b.iter_batched(
+            || message.clone(),
+            |message| message.to_octets(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let serialised = message.clone().to_octets();
+    c.bench_function("deserialise/answer/big", |b| {
+        b.iter(|| Message::from_octets(black_box(&serialised)))
+    });
+}
+
+// TODO: reduce duplication with wire_types::test_util
+fn domain(name: &str) -> DomainName {
+    DomainName::from_dotted_string(name).unwrap()
+}
+
+fn a_record(name: &str, octets: Vec<u8>) -> ResourceRecord {
+    ResourceRecord {
+        name: domain(name),
+        rtype_with_data: RecordTypeWithData::Uninterpreted {
+            rtype: RecordType::A,
+            octets,
+        },
+        rclass: RecordClass::IN,
+        ttl: 300,
+    }
+}
+
+fn cname_record(name: &str, target_name: &str) -> ResourceRecord {
+    ResourceRecord {
+        name: domain(name),
+        rtype_with_data: RecordTypeWithData::Named {
+            rtype: RecordType::CNAME,
+            name: domain(target_name),
+        },
+        rclass: RecordClass::IN,
+        ttl: 300,
+    }
+}
+
+fn ns_record(superdomain_name: &str, nameserver_name: &str) -> ResourceRecord {
+    ResourceRecord {
+        name: domain(superdomain_name),
+        rtype_with_data: RecordTypeWithData::Named {
+            rtype: RecordType::NS,
+            name: domain(nameserver_name),
+        },
+        rclass: RecordClass::IN,
+        ttl: 300,
+    }
+}
+
+criterion_group!(
+    benches,
+    bench__question,
+    bench__answer__small,
+    bench__answer__big,
+);
+criterion_main!(benches);


### PR DESCRIPTION
These are contrived but, if I'm going to consider switching to using a
library for this, they're better than nothing.

Current implementation is pretty fast:

- serialise/question       => 187.54 ns
- deserialise/question     => 216.05 ns
- serialise/answer/small   => 402.07 ns
- deserialise/answer/small => 383.23 ns
- serialise/answer/big     => 92.011 us
- deserialise/answer/big   => 167.62 us