### PR TITLE
Fix broken benchmark compilation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Run tests
         run: cargo test
 
+      - name: Check benchmarks compile
+        run: cargo bench --no-run
+
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 

--- a/benches/cache.rs
+++ b/benches/cache.rs
@@ -26,10 +26,7 @@ fn bench__insert__duplicate(c: &mut Criterion) {
             let name2 = DomainName::from_dotted_string("www.target.example.com").unwrap();
             let rr = ResourceRecord {
                 name: name1,
-                rtype_with_data: RecordTypeWithData::Named {
-                    rtype: RecordType::CNAME,
-                    name: name2,
-                },
+                rtype_with_data: RecordTypeWithData::CNAME { cname: name2 },
                 rclass: RecordClass::IN,
                 ttl: 300,
             };
@@ -148,18 +145,24 @@ fn make_rrs(size: usize, ttl: u32) -> (Vec<ResourceRecord>, Vec<(DomainName, Rec
             DomainName::from_dotted_string(&format!("www-{:?}.source.example.com", i / 2)).unwrap();
         let name2 =
             DomainName::from_dotted_string(&format!("www-{:?}.target.example.com", i / 2)).unwrap();
-        let rtype = if i % 2 == 0 {
-            RecordType::CNAME
+
+        if i % 2 == 0 {
+            queries.push((name1.clone(), RecordType::CNAME));
+            rrs.push(ResourceRecord {
+                name: name1,
+                rtype_with_data: RecordTypeWithData::CNAME { cname: name2 },
+                rclass: RecordClass::IN,
+                ttl,
+            });
         } else {
-            RecordType::NS
+            queries.push((name1.clone(), RecordType::NS));
+            rrs.push(ResourceRecord {
+                name: name1,
+                rtype_with_data: RecordTypeWithData::NS { nsdname: name2 },
+                rclass: RecordClass::IN,
+                ttl,
+            });
         };
-        queries.push((name1.clone(), rtype));
-        rrs.push(ResourceRecord {
-            name: name1,
-            rtype_with_data: RecordTypeWithData::Named { rtype, name: name2 },
-            rclass: RecordClass::IN,
-            ttl,
-        });
     }
 
     (rrs, queries)


### PR DESCRIPTION
This was broken by 89c07c3, which I missed because `cargo test`
doesn't compile the benchmarks.

To prevent this from happening in the future, CI now checks they
compile.