### PR TITLE
Remove use of `unwrap` (& rename `ProtocolError` for simplicity)

### DIFF
--- a/benches/serialise_deserialise.rs
+++ b/benches/serialise_deserialise.rs
@@ -22,7 +22,7 @@ fn bench__question(c: &mut Criterion) {
         )
     });
 
-    let serialised = message.clone().to_octets();
+    let serialised = message.clone().to_octets().unwrap();
     c.bench_function("deserialise/question", |b| {
         b.iter(|| Message::from_octets(black_box(&serialised)))
     });
@@ -50,7 +50,7 @@ fn bench__answer__small(c: &mut Criterion) {
         )
     });
 
-    let serialised = message.clone().to_octets();
+    let serialised = message.clone().to_octets().unwrap();
     c.bench_function("deserialise/answer/small", |b| {
         b.iter(|| Message::from_octets(black_box(&serialised)))
     });
@@ -97,7 +97,7 @@ fn bench__answer__big(c: &mut Criterion) {
         )
     });
 
-    let serialised = message.clone().to_octets();
+    let serialised = message.clone().to_octets().unwrap();
     c.bench_function("deserialise/answer/big", |b| {
         b.iter(|| Message::from_octets(black_box(&serialised)))
     });

--- a/fuzz/fuzz_targets/wire_deserialise_round_trip.rs
+++ b/fuzz/fuzz_targets/wire_deserialise_round_trip.rs
@@ -5,7 +5,7 @@ use resolved::protocol::wire_types::Message;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(deserialised) = Message::from_octets(data) {
-        let serialised = deserialised.clone().to_octets();
+        let serialised = deserialised.clone().to_octets().unwrap();
         let re_deserialised = Message::from_octets(&serialised);
         assert_eq!(Ok(deserialised), re_deserialised);
     }

--- a/fuzz/fuzz_targets/wire_serialise_round_trip.rs
+++ b/fuzz/fuzz_targets/wire_serialise_round_trip.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::fuzz_target;
 use resolved::protocol::wire_types::Message;
 
 fuzz_target!(|message: Message| {
-    let serialised = message.clone().to_octets();
+    let serialised = message.clone().to_octets().unwrap();
     let deserialised = Message::from_octets(&serialised);
     assert_eq!(Ok(message), deserialised);
 });

--- a/src/resolver/cache.rs
+++ b/src/resolver/cache.rs
@@ -429,16 +429,17 @@ fn to_rrs(
 ) {
     for (rtype, rclass, expires) in tuples {
         if rclass.matches(qclass) {
-            // TODO: remove use of unwrap
+            let ttl = if let Ok(ttl) = expires.saturating_duration_since(now).as_secs().try_into() {
+                ttl
+            } else {
+                u32::MAX
+            };
+
             rrs.push(ResourceRecord {
                 name: name.clone(),
                 rtype_with_data: rtype.clone(),
                 rclass: *rclass,
-                ttl: expires
-                    .saturating_duration_since(now)
-                    .as_secs()
-                    .try_into()
-                    .unwrap(),
+                ttl,
             });
         }
     }


### PR DESCRIPTION
`unwrap` is used in three places, outside of the tests:

1. In serialisation, converting sizes (as `usize`) to counters (as a smaller type, like `u16` or `u23`).

    If the `usize` is too big, there is a bug which only affects the current message: we should report it, then discard the message, which will ultimately make the request fail.  Not great, but better than crashing for *all* requests.

2. In the `SharedCache`, when the `Mutex` is poisoned.

    This is an **unrecoverable** bug: if this comes up, the cache will never work again, so there's nothing we can do but crash (or implement some scheme to totally create a new `Cache` object at runtime).  In addition, this only comes up if a thread panics while holding the lock: so if this happens, something *else* has already gone very wrong.

4. In the `Cache`, for turning `Duration`s (used for the TTL time maths) back into counter values (as `u16`).

    We already handle a `Duration` of less than zero by saturating, so we can handle a too-large `Duration` in exactly the same way.  This is probably a bug, but one we can easily recover from.