### PR TITLE
Do not cache or respond to unknown record types

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,13 @@ async fn resolve_and_build_response(
     let mut response = query.make_response();
     response.header.is_authoritative = true;
 
+    if query.questions.iter().any(|q| q.is_unknown()) {
+        response.header.rcode = Rcode::Refused;
+        response.header.is_authoritative = false;
+        println!(".");
+        return response;
+    }
+
     for question in &query.questions {
         if let Some(rr) = resolve(
             query.header.recursion_desired,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -63,42 +63,7 @@ impl Message {
     }
 }
 
-impl RecordTypeWithData {
-    pub fn rtype(&self) -> RecordType {
-        match self {
-            RecordTypeWithData::A { .. } => RecordType::A,
-            RecordTypeWithData::NS { .. } => RecordType::NS,
-            RecordTypeWithData::MD { .. } => RecordType::MD,
-            RecordTypeWithData::MF { .. } => RecordType::MF,
-            RecordTypeWithData::CNAME { .. } => RecordType::CNAME,
-            RecordTypeWithData::SOA { .. } => RecordType::SOA,
-            RecordTypeWithData::MB { .. } => RecordType::MB,
-            RecordTypeWithData::MG { .. } => RecordType::MG,
-            RecordTypeWithData::MR { .. } => RecordType::MR,
-            RecordTypeWithData::NULL { .. } => RecordType::NULL,
-            RecordTypeWithData::WKS { .. } => RecordType::WKS,
-            RecordTypeWithData::PTR { .. } => RecordType::PTR,
-            RecordTypeWithData::HINFO { .. } => RecordType::HINFO,
-            RecordTypeWithData::MINFO { .. } => RecordType::MINFO,
-            RecordTypeWithData::MX { .. } => RecordType::MX,
-            RecordTypeWithData::TXT { .. } => RecordType::TXT,
-            RecordTypeWithData::Unknown { tag, .. } => RecordType::Unknown(*tag),
-        }
-    }
-
-    pub fn matches(&self, qtype: &QueryType) -> bool {
-        self.rtype().matches(qtype)
-    }
-}
-
 impl DomainName {
-    pub fn root_domain() -> Self {
-        DomainName {
-            octets: vec![0],
-            labels: vec![vec![]],
-        }
-    }
-
     pub fn to_dotted_string(&self) -> String {
         let mut out = String::with_capacity(self.octets.len());
         let mut dot = false;
@@ -174,29 +139,6 @@ impl DomainName {
             Some(Self { octets, labels })
         } else {
             None
-        }
-    }
-
-    pub fn is_subdomain_of(&self, other: &DomainName) -> bool {
-        self.labels.ends_with(&other.labels)
-    }
-}
-
-impl RecordType {
-    pub fn matches(&self, qtype: &QueryType) -> bool {
-        match qtype {
-            QueryType::Wildcard => true,
-            QueryType::Record(rtype) => rtype == self,
-            _ => false,
-        }
-    }
-}
-
-impl RecordClass {
-    pub fn matches(&self, qclass: &QueryClass) -> bool {
-        match qclass {
-            QueryClass::Wildcard => true,
-            QueryClass::Record(rclass) => rclass == self,
         }
     }
 }

--- a/src/protocol/wire_types.rs
+++ b/src/protocol/wire_types.rs
@@ -1127,4 +1127,16 @@ pub mod test_util {
             ttl: 300,
         }
     }
+
+    pub fn unknown_record(name: &str, octets: &[u8]) -> ResourceRecord {
+        ResourceRecord {
+            name: domain(name),
+            rtype_with_data: RecordTypeWithData::Unknown {
+                tag: RecordTypeUnknown(100),
+                octets: octets.into(),
+            },
+            rclass: RecordClass::IN,
+            ttl: 300,
+        }
+    }
 }


### PR DESCRIPTION
Records aren't just a black box, they have to be interpreted depending on their type: just passing them on to clients as-is may be incorrect.

For example, the CNAME record type holds a domain name.  DNS messages have a compression scheme for domain names, based on pointers.  If a CNAME record with a compressed domain name were passed along unchanged to a client, the pointer would almost certainly be invalid, as it refers to a location in the message from the upstream nameserver - not the message `resolved` has just generated.  So domain names need to be uncompressed before being sent to a client (and, optionally, be re-compressed in a way the client will understand).

Other record types may do the same.  But who knows?  I've not read the RFCs defining them yet.

So this PR introduces some new behaviour:

1. If the response from an upstream nameserver includes RRs of unknown type, they are dropped before being returned.  This means we can't respond to a client with such RRs and they don't get cached.
2. If any of the questions from a client are for an unknown record type or class, we respond with a "refused" error.  This is, strictly speaking, not required: due to (1) we would find to fail any RRs and so return a "server failure" error.  But "refused" seems better.

Closes #21