### PR TITLE
Add config option to specify which interface to bind to

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,3 +1,5 @@
+interface: "127.0.0.1"
+
 root_hints:
   - "198.41.0.4"     # a.root-servers.net
   - "199.9.14.201"   # b.root-servers.net

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -290,6 +290,7 @@ mod tests {
 
     fn local_zone(records: &[(DomainName, Ipv4Addr)]) -> Settings {
         Settings {
+            interface: None,
             root_hints: Vec::new(),
             hosts_files: Vec::new(),
             static_records: records

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use bytes::BytesMut;
 use std::env;
+use std::net::Ipv4Addr;
 use std::path::Path;
 use std::process;
 use std::time::Duration;
@@ -238,7 +239,10 @@ async fn main() {
         }
     }
 
-    let udp = match UdpSocket::bind("127.0.0.1:53").await {
+    let interface = settings.interface.unwrap_or(Ipv4Addr::UNSPECIFIED);
+    println!("binding to {:?}", interface);
+
+    let udp = match UdpSocket::bind((interface, 53)).await {
         Ok(s) => s,
         Err(err) => {
             eprintln!("error binding bind UDP socket: {:?}", err);
@@ -246,7 +250,7 @@ async fn main() {
         }
     };
 
-    let tcp = match TcpListener::bind("127.0.0.1:53").await {
+    let tcp = match TcpListener::bind((interface, 53)).await {
         Ok(s) => s,
         Err(err) => {
             eprintln!("error binding bind TCP socket: {:?}", err);

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1312,6 +1312,7 @@ mod tests {
         };
 
         Settings {
+            interface: None,
             root_hints: Vec::new(),
             static_records: vec![
                 Record {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -9,6 +9,8 @@ use crate::protocol::wire_types::DomainName;
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Default)]
 pub struct Settings {
     #[serde(default)]
+    pub interface: Option<Ipv4Addr>,
+    #[serde(default)]
     pub root_hints: Vec<Ipv4Addr>,
     #[serde(default)]
     pub static_records: Vec<Record>,


### PR DESCRIPTION
This defaults to `0.0.0.0`, but the configuration file has `127.0.0.1`
to show it working.

Closes #28