### PR TITLE
Extract a generic data structure from the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Development
 The project structure should hopefully be fairly straightforward.  The
 modules are:
 
+- `collections` - data structures
 - `hosts`    - the parser for hosts files
 - `net_util` - shared utilities used by both the `main.rs` file and the `resolver` module
 - `protocol` - the DNS message types and serialisation / deserialisation logic

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,0 +1,1 @@
+pub mod namespaced_cache;

--- a/src/collections/namespaced_cache.rs
+++ b/src/collections/namespaced_cache.rs
@@ -1,0 +1,552 @@
+use priority_queue::PriorityQueue;
+use std::cmp::{Eq, PartialEq, Reverse};
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::time::Instant;
+
+/// A size-bounded cache, using LRU (Least Recently Used) eviction
+/// order, with entry expiration.  Entries are stored under a
+/// namespaced key, which allows efficient retrieval of all entries
+/// under the top-level key.
+#[derive(Debug, Clone)]
+pub struct NamespacedCache<Kn: Eq + Hash, Ki: Eq + Hash, V> {
+    /// Cached records, indexed by namespace key.
+    namespaces: HashMap<Kn, Namespace<Ki, V>>,
+
+    /// Priority queue of namespace keys ordered by access times.
+    ///
+    /// When the cache is full and there are no expired records to
+    /// prune, namespaces will instead be pruned in LRU order.
+    ///
+    /// INVARIANT: the keys in here are exactly the keys in
+    /// `namespaces`.
+    access_priority: PriorityQueue<Kn, Reverse<Instant>>,
+
+    /// Priority queue of namespace keys ordered by expiry time.
+    ///
+    /// When the cache is pruned, expired entries are removed first.
+    ///
+    /// INVARIANT: the keys in here are exactly the keys in
+    /// `namespaces`.
+    expiry_priority: PriorityQueue<Kn, Reverse<Instant>>,
+
+    /// The number of entries in the cache.
+    ///
+    /// INVARIANT: this is the sum of the `size` fields of the
+    /// `namespaces`.
+    current_size: usize,
+
+    /// The desired maximum number of records in the cache.
+    desired_size: usize,
+}
+
+/// The cached entries under a specific namespace.
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct Namespace<Ki: Eq + Hash, V> {
+    /// The time these entries were last read at.
+    last_read: Instant,
+
+    /// When the next entry expires.
+    ///
+    /// INVARIANT: this is the minimum of the expiry times of the
+    /// entries.
+    next_expiry: Instant,
+
+    /// How many entries there are.
+    ///
+    /// INVARIANT: this is the sum of the vector lengths in `entries`.
+    size: usize,
+
+    /// The entries, divided by key.
+    entries: HashMap<Ki, Vec<Entry<V>>>,
+}
+
+/// An entry in the cache.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Entry<V> {
+    pub value: V,
+    pub expires_at: Instant,
+}
+
+impl<Kn: Clone + Eq + Hash, Ki: Eq + Hash, V: Clone + PartialEq> Default
+    for NamespacedCache<Kn, Ki, V>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Kn: Clone + Eq + Hash, Ki: Eq + Hash, V: Clone + PartialEq> NamespacedCache<Kn, Ki, V> {
+    /// Create a new cache with a default desired size.
+    pub fn new() -> Self {
+        Self::with_desired_size(512)
+    }
+
+    /// Create a new cache with the given desired size.
+    ///
+    /// If the number of entries exceeds this, expired and
+    /// least-recently-used items will be pruned.
+    ///
+    /// Panics:
+    ///
+    /// - If called with a desired_size of 0.
+    pub fn with_desired_size(desired_size: usize) -> Self {
+        // allocate space for 32 entries beyond the desired size,
+        // since pruning is not done synchronously with insertion
+        Self::with_desired_size_and_flex(desired_size, 32)
+    }
+
+    /// Create a new cache with the given desired size and flex.
+    ///
+    /// If the number of entries exceeds the desired size, expired and
+    /// least-recently-used items will be pruned.  To reduce the
+    /// likelihood of needing to grow the internal data structures,
+    /// they are sized to hold `desired_size + flex` entries.
+    ///
+    /// Panics:
+    ///
+    /// - If called with a desired_size of 0.
+    pub fn with_desired_size_and_flex(desired_size: usize, flex: usize) -> Self {
+        if desired_size == 0 {
+            panic!("cannot create a zero-size cache");
+        }
+
+        let capacity = desired_size + flex;
+
+        Self {
+            // `capacity / 2` is based on the assumption that most
+            // namespaces will have more than one entry inside them.
+            namespaces: HashMap::with_capacity(capacity / 2),
+            access_priority: PriorityQueue::with_capacity(capacity),
+            expiry_priority: PriorityQueue::with_capacity(capacity),
+            current_size: 0,
+            desired_size,
+        }
+    }
+
+    /// Return the number of entries in the cache.
+    pub fn len(&self) -> usize {
+        self.current_size
+    }
+
+    /// Return whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.current_size == 0
+    }
+
+    /// Get all entries from the cache matching the namespace key,
+    /// regardless of inner key.
+    ///
+    /// If any expired entries are retrieved, they are removed and the
+    /// cache is evicted.
+    pub fn get_all(&mut self, now: Instant, namespace_key: &Kn) -> Vec<Entry<V>> {
+        let mut out = self.get_all_without_checking_expiration(now, namespace_key);
+        let len = out.len();
+        out.retain(|x| x.expires_at > now);
+        if out.len() != len {
+            self.remove_expired(now);
+        }
+        out
+    }
+
+    /// Get all entries from the cache matching the namespace key,
+    /// regardless of inner key.
+    ///
+    /// These entries may have expired.  Consumers MUST check before
+    /// using the record!
+    pub fn get_all_without_checking_expiration(
+        &mut self,
+        now: Instant,
+        namespace_key: &Kn,
+    ) -> Vec<Entry<V>> {
+        if let Some(namespace) = self.namespaces.get_mut(namespace_key) {
+            let mut out = Vec::with_capacity(namespace.size);
+            for entries in namespace.entries.values() {
+                out.append(&mut entries.clone());
+            }
+            if !out.is_empty() {
+                namespace.last_read = now;
+                self.access_priority
+                    .change_priority(namespace_key, Reverse(namespace.last_read));
+            }
+            out
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Get all entries from the cache matching both the namespace and
+    /// inner keys.
+    ///
+    /// If any expired entries are retrieved, they are removed and the
+    /// cache is evicted.
+    pub fn get(&mut self, now: Instant, namespace_key: &Kn, inner_key: &Ki) -> Vec<Entry<V>> {
+        let mut out = self.get_without_checking_expiration(now, namespace_key, inner_key);
+        let len = out.len();
+        out.retain(|x| x.expires_at > now);
+        if out.len() != len {
+            self.remove_expired(now);
+        }
+        out
+    }
+
+    /// Get all entries from the cache matching both the namespace and
+    /// inner keys.
+    ///
+    /// These entries may have expired.  Consumers MUST check before
+    /// using the record!
+    pub fn get_without_checking_expiration(
+        &mut self,
+        now: Instant,
+        namespace_key: &Kn,
+        inner_key: &Ki,
+    ) -> Vec<Entry<V>> {
+        if let Some(namespace) = self.namespaces.get_mut(namespace_key) {
+            if let Some(entries) = namespace.entries.get(inner_key) {
+                if !entries.is_empty() {
+                    namespace.last_read = now;
+                    self.access_priority
+                        .change_priority(namespace_key, Reverse(namespace.last_read));
+                }
+                entries.clone()
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Insert an entry into the cache.
+    ///
+    /// If it is equal to an entry already in the cache, the
+    /// expiration time of the existing entry is updated instead.
+    pub fn insert(
+        &mut self,
+        now: Instant,
+        namespace_key: Kn,
+        inner_key: Ki,
+        value: V,
+        expires_at: Instant,
+    ) {
+        if let Some(namespace) = self.namespaces.get_mut(&namespace_key) {
+            if let Some(entries) = namespace.entries.get_mut(&inner_key) {
+                let mut duplicate_expires_at = None;
+                for i in 0..entries.len() {
+                    let entry = &entries[i];
+                    if entry.value == value {
+                        duplicate_expires_at = Some(entry.expires_at);
+                        entries.swap_remove(i);
+                        break;
+                    }
+                }
+
+                entries.push(Entry { value, expires_at });
+
+                if let Some(dup_expiry) = duplicate_expires_at {
+                    namespace.size -= 1;
+                    self.current_size -= 1;
+
+                    if dup_expiry == namespace.next_expiry {
+                        namespace.next_expiry = entries
+                            .iter()
+                            .map(|e| e.expires_at)
+                            .min()
+                            .unwrap_or(expires_at);
+                        self.expiry_priority
+                            .change_priority(&namespace_key, Reverse(namespace.next_expiry));
+                    }
+                }
+            } else {
+                namespace
+                    .entries
+                    .insert(inner_key, vec![Entry { value, expires_at }]);
+            }
+
+            namespace.last_read = now;
+            namespace.size += 1;
+
+            self.access_priority
+                .change_priority(&namespace_key, Reverse(namespace.last_read));
+
+            if expires_at < namespace.next_expiry {
+                namespace.next_expiry = expires_at;
+                self.expiry_priority
+                    .change_priority(&namespace_key, Reverse(namespace.next_expiry));
+            }
+        } else {
+            let mut entries = HashMap::new();
+            entries.insert(inner_key, vec![Entry { value, expires_at }]);
+            let namespace = Namespace {
+                last_read: now,
+                next_expiry: expires_at,
+                size: 1,
+                entries,
+            };
+            self.access_priority
+                .push(namespace_key.clone(), Reverse(namespace.last_read));
+            self.expiry_priority
+                .push(namespace_key.clone(), Reverse(namespace.next_expiry));
+            self.namespaces.insert(namespace_key, namespace);
+        }
+
+        self.current_size += 1;
+    }
+
+    /// Delete all expired records.
+    ///
+    /// Returns the number of records deleted.
+    pub fn remove_expired(&mut self, now: Instant) -> usize {
+        let mut pruned = 0;
+
+        loop {
+            let before = pruned;
+            pruned += self.remove_expired_step(now);
+            if before == pruned {
+                break;
+            }
+        }
+
+        pruned
+    }
+
+    /// Delete all expired records, and then enough
+    /// least-recently-used records to reduce the cache to the desired
+    /// size.
+    ///
+    /// Returns the number of records deleted.
+    pub fn prune(&mut self, now: Instant) -> usize {
+        if self.current_size <= self.desired_size {
+            return 0;
+        }
+
+        let mut pruned = self.remove_expired(now);
+
+        while self.current_size > self.desired_size {
+            pruned += self.remove_least_recently_used();
+        }
+
+        pruned
+    }
+
+    /// Helper for `remove_expired`: looks at the next-to-expire
+    /// domain and cleans up expired records from it.  This may delete
+    /// more than one record, and may even delete the whole domain.
+    ///
+    /// Returns the number of records removed.
+    fn remove_expired_step(&mut self, now: Instant) -> usize {
+        if let Some((namespace_key, Reverse(expiry))) = self.expiry_priority.pop() {
+            if expiry > now {
+                self.expiry_priority.push(namespace_key, Reverse(expiry));
+                return 0;
+            }
+
+            if let Some(namespace) = self.namespaces.get_mut(&namespace_key) {
+                let mut pruned = 0;
+
+                let mut next_expiry = None;
+                for entries in namespace.entries.values_mut() {
+                    let len = entries.len();
+                    entries.retain(|e| e.expires_at > now);
+                    pruned += len - entries.len();
+                    for e in entries {
+                        next_expiry = match next_expiry {
+                            Some(t) => Some(std::cmp::min(t, e.expires_at)),
+                            None => Some(e.expires_at),
+                        };
+                    }
+                }
+
+                namespace.size -= pruned;
+
+                if let Some(ne) = next_expiry {
+                    println!(
+                        "setting next expiry from {:?} to {:?}",
+                        namespace.next_expiry, ne
+                    );
+                    namespace.next_expiry = ne;
+                    self.expiry_priority.push(namespace_key, Reverse(ne));
+                } else {
+                    self.namespaces.remove(&namespace_key);
+                    self.access_priority.remove(&namespace_key);
+                }
+
+                self.current_size -= pruned;
+                pruned
+            } else {
+                self.access_priority.remove(&namespace_key);
+                0
+            }
+        } else {
+            0
+        }
+    }
+
+    /// Helper for `prune`: deletes all records associated with the
+    /// least recently used domain.
+    ///
+    /// Returns the number of records removed.
+    fn remove_least_recently_used(&mut self) -> usize {
+        if let Some((namespace_key, _)) = self.access_priority.pop() {
+            self.expiry_priority.remove(&namespace_key);
+
+            if let Some(namespace) = self.namespaces.remove(&namespace_key) {
+                self.current_size -= namespace.size;
+                namespace.size
+            } else {
+                0
+            }
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    // the cache doesn't depend on the wire types, but it's convenient
+    // to re-use a random test data generator I already have.
+    use crate::protocol::wire_types::test_util::*;
+    use crate::protocol::wire_types::*;
+
+    #[test]
+    fn cache_put_deduplicates_and_maintains_invariants() {
+        let now = Instant::now();
+        let mut cache = NamespacedCache::new();
+        let rr = arbitrary_resourcerecord();
+
+        insert_rr(now, &mut cache, rr.clone());
+        insert_rr(now, &mut cache, rr);
+
+        assert_eq!(1, cache.len());
+        assert_invariants(&cache);
+    }
+
+    #[test]
+    fn cache_put_maintains_invariants() {
+        let now = Instant::now();
+        let mut cache = NamespacedCache::new();
+
+        for _ in 0..100 {
+            insert_rr(now, &mut cache, arbitrary_resourcerecord());
+        }
+
+        assert_invariants(&cache);
+    }
+
+    #[test]
+    fn cache_put_then_get_maintains_invariants() {
+        let now = Instant::now();
+        let mut cache = NamespacedCache::new();
+        let mut queries = Vec::new();
+
+        for _ in 0..100 {
+            let rr = arbitrary_resourcerecord();
+            insert_rr(now, &mut cache, rr.clone());
+            queries.push((rr.name.clone(), rr.rtype_with_data.rtype()));
+        }
+        for (namespace_key, inner_key) in queries {
+            cache.get_without_checking_expiration(now, &namespace_key, &inner_key);
+        }
+
+        assert_invariants(&cache);
+    }
+
+    #[test]
+    fn cache_put_then_prune_maintains_invariants() {
+        let now = Instant::now();
+        let mut cache = NamespacedCache::with_desired_size(25);
+
+        for _ in 0..100 {
+            let mut rr = arbitrary_resourcerecord();
+            rr.ttl = 300; // not testing expiry in this case
+            insert_rr(now, &mut cache, rr);
+        }
+
+        assert_eq!(75, cache.prune(now));
+        assert_eq!(25, cache.len());
+        assert_invariants(&cache);
+    }
+
+    #[test]
+    fn cache_put_then_expire_maintains_invariants() {
+        let now = Instant::now();
+        let mut cache = NamespacedCache::new();
+
+        for i in 0..100 {
+            let mut rr = arbitrary_resourcerecord();
+            rr.ttl = if i > 0 && i % 2 == 0 { 0 } else { 300 };
+            insert_rr(now, &mut cache, rr);
+        }
+
+        assert_eq!(49, cache.remove_expired(now));
+        assert_eq!(51, cache.current_size);
+        assert_invariants(&cache);
+    }
+
+    #[test]
+    fn cache_prune_expires_all() {
+        let now = Instant::now();
+        let mut cache = NamespacedCache::with_desired_size(99);
+
+        for i in 0..100 {
+            let mut rr = arbitrary_resourcerecord();
+            rr.ttl = if i > 0 && i % 2 == 0 { 0 } else { 300 };
+            insert_rr(now, &mut cache, rr);
+        }
+
+        assert_eq!(49, cache.prune(now));
+    }
+
+    fn insert_rr(
+        now: Instant,
+        cache: &mut NamespacedCache<DomainName, RecordType, (RecordTypeWithData, RecordClass)>,
+        rr: ResourceRecord,
+    ) {
+        cache.insert(
+            now,
+            rr.name,
+            rr.rtype_with_data.rtype(),
+            (rr.rtype_with_data, rr.rclass),
+            now + Duration::from_secs(rr.ttl as u64),
+        );
+    }
+
+    fn assert_invariants(
+        cache: &NamespacedCache<DomainName, RecordType, (RecordTypeWithData, RecordClass)>,
+    ) {
+        assert_eq!(
+            cache.current_size,
+            cache.namespaces.values().map(|e| e.size).sum::<usize>()
+        );
+
+        assert_eq!(cache.namespaces.len(), cache.access_priority.len());
+        assert_eq!(cache.namespaces.len(), cache.expiry_priority.len());
+
+        let mut access_priority = PriorityQueue::new();
+        let mut expiry_priority = PriorityQueue::new();
+
+        for (namespace_key, namespace) in cache.namespaces.iter() {
+            let size = namespace.entries.values().map(|r| r.len()).sum::<usize>();
+
+            let next_expiry = namespace
+                .entries
+                .values()
+                .filter_map(|vs| vs.iter().map(|v| v.expires_at).min())
+                .min();
+
+            assert_eq!(size, namespace.size);
+            assert_eq!(next_expiry, Some(namespace.next_expiry));
+
+            access_priority.push(namespace_key.clone(), Reverse(namespace.last_read));
+            expiry_priority.push(namespace_key.clone(), Reverse(namespace.next_expiry));
+        }
+
+        assert_eq!(cache.access_priority, access_priority);
+        assert_eq!(cache.expiry_priority, expiry_priority);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod collections;
 pub mod hosts;
 pub mod net_util;
 pub mod protocol;

--- a/src/resolver/cache.rs
+++ b/src/resolver/cache.rs
@@ -1,9 +1,7 @@
-use priority_queue::PriorityQueue;
-use std::cmp::Reverse;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::collections::namespaced_cache::NamespacedCache;
 use crate::protocol::wire_types::*;
 
 /// A convenience wrapper around a `Cache` which lets it be shared
@@ -13,7 +11,8 @@ use crate::protocol::wire_types::*;
 /// refers to the same underlying `Cache` object.
 #[derive(Debug, Clone)]
 pub struct SharedCache {
-    cache: Arc<Mutex<Cache>>,
+    #[allow(clippy::type_complexity)]
+    cache: Arc<Mutex<NamespacedCache<DomainName, RecordType, (RecordTypeWithData, RecordClass)>>>,
 }
 
 const MUTEX_POISON_MESSAGE: &str =
@@ -23,7 +22,7 @@ impl SharedCache {
     /// Make a new, empty, shared cache.
     pub fn new() -> Self {
         SharedCache {
-            cache: Arc::new(Mutex::new(Cache::new())),
+            cache: Arc::new(Mutex::new(NamespacedCache::new())),
         }
     }
 
@@ -38,41 +37,59 @@ impl SharedCache {
         qtype: &QueryType,
         qclass: &QueryClass,
     ) -> Vec<ResourceRecord> {
-        let mut rrs = self.get_without_checking_expiration(name, qtype, qclass);
-        let len = rrs.len();
-        rrs.retain(|rr| rr.ttl > 0);
-        if rrs.len() != len {
-            self.remove_expired();
-        }
-        rrs
-    }
-
-    /// Like `get`, but may return expired entries.
-    ///
-    /// Consumers MUST check that the TTL of a record is nonzero
-    /// before using it!
-    pub fn get_without_checking_expiration(
-        &self,
-        name: &DomainName,
-        qtype: &QueryType,
-        qclass: &QueryClass,
-    ) -> Vec<ResourceRecord> {
-        self.cache
-            .lock()
-            .expect(MUTEX_POISON_MESSAGE)
-            .get_without_checking_expiration(name, qtype, qclass)
+        let now = Instant::now();
+        let records = {
+            let mut cache = self.cache.lock().expect(MUTEX_POISON_MESSAGE);
+            match qtype {
+                QueryType::Wildcard => cache.get_all(now, name),
+                QueryType::Record(rtype) => cache.get(now, name, rtype),
+                _ => return Vec::new(),
+            }
+        };
+        records
+            .into_iter()
+            .filter_map(|e| {
+                let (rtype_with_data, rclass) = e.value;
+                if rclass.matches(qclass) {
+                    let ttl = if let Ok(ttl) = e
+                        .expires_at
+                        .saturating_duration_since(now)
+                        .as_secs()
+                        .try_into()
+                    {
+                        ttl
+                    } else {
+                        u32::MAX
+                    };
+                    Some(ResourceRecord {
+                        name: name.clone(),
+                        rtype_with_data,
+                        rclass,
+                        ttl,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Insert an entry into the cache.
     ///
     /// It is not inserted if its TTL is zero.
     pub fn insert(&self, record: &ResourceRecord) {
+        let now = Instant::now();
         if record.ttl > 0 {
             let mut cache = self.cache.lock().expect(MUTEX_POISON_MESSAGE);
-            cache.insert(record);
-            if cache.current_size > cache.desired_size {
-                cache.prune();
-            }
+            cache.insert(
+                now,
+                record.name.clone(),
+                record.rtype_with_data.rtype(),
+                (record.rtype_with_data.clone(), record.rclass),
+                now + Duration::from_secs(record.ttl as u64),
+            );
+
+            cache.prune(now);
         }
     }
 
@@ -83,7 +100,7 @@ impl SharedCache {
         self.cache
             .lock()
             .expect(MUTEX_POISON_MESSAGE)
-            .remove_expired()
+            .remove_expired(Instant::now())
     }
 
     /// Delete all expired records, and then enough
@@ -92,357 +109,16 @@ impl SharedCache {
     ///
     /// Returns the number of records deleted.
     pub fn prune(&self) -> usize {
-        self.cache.lock().expect(MUTEX_POISON_MESSAGE).prune()
+        self.cache
+            .lock()
+            .expect(MUTEX_POISON_MESSAGE)
+            .prune(Instant::now())
     }
 }
 
 impl Default for SharedCache {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Caching for `ResourceRecord`s.
-///
-/// You probably want to use `SharedCache` instead.
-#[derive(Debug, Clone)]
-pub struct Cache {
-    /// Cached records, indexed by domain name.
-    ///
-    /// TODO: see if some other structure, like a trie using the name
-    /// labels, would be better here.
-    entries: HashMap<DomainName, CachedDomainRecords>,
-
-    /// Priority queue of domain names ordered by access times.
-    ///
-    /// When the cache is full and there are no expired records to
-    /// prune, domains will instead be pruned in LRU order.
-    ///
-    /// INVARIANT: the domains in here are exactly the domains in
-    /// `entries`.
-    access_priority: PriorityQueue<DomainName, Reverse<Instant>>,
-
-    /// Priority queue of domain names ordered by expiry time.
-    ///
-    /// When the cache is pruned, expired records are removed first.
-    ///
-    /// INVARIANT: the domains in here are exactly the domains in
-    /// `entries`.
-    expiry_priority: PriorityQueue<DomainName, Reverse<Instant>>,
-
-    /// The number of records in the cache.
-    ///
-    /// INVARIANT: this is the sum of the `size` fields of the
-    /// entries.
-    current_size: usize,
-
-    /// The desired maximum number of records in the cache.
-    desired_size: usize,
-}
-
-/// The cached records for a domain.
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct CachedDomainRecords {
-    /// The time this record was last read at.
-    last_read: Instant,
-
-    /// When the next RR expires.
-    ///
-    /// INVARIANT: this is the minimum of the expiry times of the RRs.
-    next_expiry: Instant,
-
-    /// How many records there are.
-    ///
-    /// INVARIANT: this is the sum of the vector lengths in `records`.
-    size: usize,
-
-    /// The records, further divided by record type.
-    ///
-    /// INVARIANT: the `RecordType` and `RecordTypeWithData` match.
-    records: HashMap<RecordType, Vec<(RecordTypeWithData, RecordClass, Instant)>>,
-}
-
-impl Default for Cache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Cache {
-    /// Create a new cache with a default desired size.
-    pub fn new() -> Self {
-        Self::with_desired_size(512)
-    }
-
-    /// Create a new cache with the given desired size.
-    ///
-    /// If the number of entries exceeds this, expired and
-    /// least-recently-used items will be pruned.
-    ///
-    /// Panics:
-    ///
-    /// - If called with a desired_size of 0.
-    pub fn with_desired_size(desired_size: usize) -> Self {
-        if desired_size == 0 {
-            panic!("cannot create a zero-size cache");
-        }
-
-        Self {
-            // `desired_size / 2` is a compromise: most domains will
-            // have more than one record, so `desired_size` would be
-            // too big for the `entries`.
-            entries: HashMap::with_capacity(desired_size / 2),
-            access_priority: PriorityQueue::with_capacity(desired_size),
-            expiry_priority: PriorityQueue::with_capacity(desired_size),
-            current_size: 0,
-            desired_size,
-        }
-    }
-
-    /// Get an entry from the cache.
-    ///
-    /// The TTL in the returned `ResourceRecord` is relative to the
-    /// current time - not when the record was inserted into the
-    /// cache.
-    ///
-    /// This entry may have expired: if so, the TTL will be 0.
-    /// Consumers MUST check this before using the record!
-    pub fn get_without_checking_expiration(
-        &mut self,
-        name: &DomainName,
-        qtype: &QueryType,
-        qclass: &QueryClass,
-    ) -> Vec<ResourceRecord> {
-        if let Some(entry) = self.entries.get_mut(name) {
-            let now = Instant::now();
-            let mut rrs = Vec::new();
-            match qtype {
-                QueryType::Wildcard => {
-                    for tuples in entry.records.values() {
-                        to_rrs(name, qclass, now, tuples, &mut rrs);
-                    }
-                }
-                QueryType::Record(rtype) => {
-                    if let Some(tuples) = entry.records.get(rtype) {
-                        to_rrs(name, qclass, now, tuples, &mut rrs);
-                    }
-                }
-                _ => (),
-            }
-            if !rrs.is_empty() {
-                entry.last_read = now;
-                self.access_priority
-                    .change_priority(name, Reverse(entry.last_read));
-            }
-            rrs
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Insert an entry into the cache.
-    pub fn insert(&mut self, record: &ResourceRecord) {
-        let now = Instant::now();
-        let rtype = record.rtype_with_data.rtype();
-        let expiry = Instant::now() + Duration::from_secs(record.ttl.into());
-        let tuple = (record.rtype_with_data.clone(), record.rclass, expiry);
-        if let Some(entry) = self.entries.get_mut(&record.name) {
-            if let Some(tuples) = entry.records.get_mut(&rtype) {
-                let mut duplicate_expires_at = None;
-                for i in 0..tuples.len() {
-                    let t = &tuples[i];
-                    if t.0 == tuple.0 && t.1 == tuple.1 {
-                        duplicate_expires_at = Some(t.2);
-                        tuples.swap_remove(i);
-                        break;
-                    }
-                }
-
-                tuples.push(tuple);
-
-                if let Some(dup_expiry) = duplicate_expires_at {
-                    entry.size -= 1;
-                    self.current_size -= 1;
-
-                    if dup_expiry == entry.next_expiry {
-                        let mut new_next_expiry = expiry;
-                        for (_, _, e) in tuples {
-                            if *e < new_next_expiry {
-                                new_next_expiry = *e;
-                            }
-                        }
-                        entry.next_expiry = new_next_expiry;
-                        self.expiry_priority
-                            .change_priority(&record.name, Reverse(entry.next_expiry));
-                    }
-                }
-            } else {
-                entry.records.insert(rtype, vec![tuple]);
-            }
-            entry.last_read = now;
-            entry.size += 1;
-            self.access_priority
-                .change_priority(&record.name, Reverse(entry.last_read));
-            if expiry < entry.next_expiry {
-                entry.next_expiry = expiry;
-                self.expiry_priority
-                    .change_priority(&record.name, Reverse(entry.next_expiry));
-            }
-        } else {
-            let mut records = HashMap::new();
-            records.insert(rtype, vec![tuple]);
-            let entry = CachedDomainRecords {
-                last_read: now,
-                next_expiry: expiry,
-                size: 1,
-                records,
-            };
-            self.access_priority
-                .push(record.name.clone(), Reverse(entry.last_read));
-            self.expiry_priority
-                .push(record.name.clone(), Reverse(entry.next_expiry));
-            self.entries.insert(record.name.clone(), entry);
-        }
-
-        self.current_size += 1;
-    }
-
-    /// Delete all expired records.
-    ///
-    /// Returns the number of records deleted.
-    pub fn remove_expired(&mut self) -> usize {
-        let mut pruned = 0;
-
-        loop {
-            let before = pruned;
-            pruned += self.remove_expired_step();
-            if before == pruned {
-                break;
-            }
-        }
-
-        pruned
-    }
-
-    /// Delete all expired records, and then enough
-    /// least-recently-used records to reduce the cache to the desired
-    /// size.
-    ///
-    /// Returns the number of records deleted.
-    pub fn prune(&mut self) -> usize {
-        if self.current_size <= self.desired_size {
-            return 0;
-        }
-
-        let mut pruned = self.remove_expired();
-
-        while self.current_size > self.desired_size {
-            pruned += self.remove_least_recently_used();
-        }
-
-        pruned
-    }
-
-    /// Helper for `remove_expired`: looks at the next-to-expire
-    /// domain and cleans up expired records from it.  This may delete
-    /// more than one record, and may even delete the whole domain.
-    ///
-    /// Returns the number of records removed.
-    fn remove_expired_step(&mut self) -> usize {
-        if let Some((name, Reverse(expiry))) = self.expiry_priority.pop() {
-            let now = Instant::now();
-
-            if expiry > now {
-                self.expiry_priority.push(name, Reverse(expiry));
-                return 0;
-            }
-
-            if let Some(entry) = self.entries.get_mut(&name) {
-                let mut pruned = 0;
-
-                let rtypes = entry.records.keys().cloned().collect::<Vec<RecordType>>();
-                let mut next_expiry = None;
-                for rtype in rtypes {
-                    if let Some(tuples) = entry.records.get_mut(&rtype) {
-                        let len = tuples.len();
-                        tuples.retain(|(_, _, expiry)| expiry > &now);
-                        pruned += len - tuples.len();
-                        for (_, _, expiry) in tuples {
-                            match next_expiry {
-                                None => next_expiry = Some(*expiry),
-                                Some(t) if *expiry < t => next_expiry = Some(*expiry),
-                                _ => (),
-                            }
-                        }
-                    }
-                }
-
-                entry.size -= pruned;
-
-                if let Some(ne) = next_expiry {
-                    entry.next_expiry = ne;
-                    self.expiry_priority.push(name, Reverse(ne));
-                } else {
-                    self.entries.remove(&name);
-                    self.access_priority.remove(&name);
-                }
-
-                self.current_size -= pruned;
-                pruned
-            } else {
-                self.access_priority.remove(&name);
-                0
-            }
-        } else {
-            0
-        }
-    }
-
-    /// Helper for `prune`: deletes all records associated with the
-    /// least recently used domain.
-    ///
-    /// Returns the number of records removed.
-    fn remove_least_recently_used(&mut self) -> usize {
-        if let Some((name, _)) = self.access_priority.pop() {
-            self.expiry_priority.remove(&name);
-
-            if let Some(entry) = self.entries.remove(&name) {
-                let pruned = entry.size;
-                self.current_size -= pruned;
-                pruned
-            } else {
-                0
-            }
-        } else {
-            0
-        }
-    }
-}
-
-/// Helper for `get_without_checking_expiration`: converts the cached
-/// record tuples into RRs.
-fn to_rrs(
-    name: &DomainName,
-    qclass: &QueryClass,
-    now: Instant,
-    tuples: &[(RecordTypeWithData, RecordClass, Instant)],
-    rrs: &mut Vec<ResourceRecord>,
-) {
-    for (rtype, rclass, expires) in tuples {
-        if rclass.matches(qclass) {
-            let ttl = if let Ok(ttl) = expires.saturating_duration_since(now).as_secs().try_into() {
-                ttl
-            } else {
-                u32::MAX
-            };
-
-            rrs.push(ResourceRecord {
-                name: name.clone(),
-                rtype_with_data: rtype.clone(),
-                rclass: *rclass,
-                ttl,
-            });
-        }
     }
 }
 
@@ -455,13 +131,14 @@ mod tests {
     #[test]
     fn cache_put_can_get() {
         for _ in 0..100 {
-            let mut cache = Cache::new();
-            let rr = arbitrary_resourcerecord();
+            let cache = SharedCache::new();
+            let mut rr = arbitrary_resourcerecord();
+            rr.ttl = 300; // ensure it doesn't expire immediately
             cache.insert(&rr);
 
             assert_cache_response(
                 &rr,
-                cache.get_without_checking_expiration(
+                cache.get(
                     &rr.name,
                     &QueryType::Record(rr.rtype_with_data.rtype()),
                     &QueryClass::Record(rr.rclass),
@@ -469,7 +146,7 @@ mod tests {
             );
             assert_cache_response(
                 &rr,
-                cache.get_without_checking_expiration(
+                cache.get(
                     &rr.name,
                     &QueryType::Wildcard,
                     &QueryClass::Record(rr.rclass),
@@ -477,7 +154,7 @@ mod tests {
             );
             assert_cache_response(
                 &rr,
-                cache.get_without_checking_expiration(
+                cache.get(
                     &rr.name,
                     &QueryType::Record(rr.rtype_with_data.rtype()),
                     &QueryClass::Wildcard,
@@ -485,141 +162,9 @@ mod tests {
             );
             assert_cache_response(
                 &rr,
-                cache.get_without_checking_expiration(
-                    &rr.name,
-                    &QueryType::Wildcard,
-                    &QueryClass::Wildcard,
-                ),
+                cache.get(&rr.name, &QueryType::Wildcard, &QueryClass::Wildcard),
             );
         }
-    }
-
-    #[test]
-    fn cache_put_deduplicates_and_maintains_invariants() {
-        let mut cache = Cache::new();
-        let rr = arbitrary_resourcerecord();
-
-        cache.insert(&rr);
-        cache.insert(&rr);
-
-        assert_eq!(1, cache.current_size);
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_maintains_invariants() {
-        let mut cache = Cache::new();
-
-        for _ in 0..100 {
-            cache.insert(&arbitrary_resourcerecord());
-        }
-
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_then_get_maintains_invariants() {
-        let mut cache = Cache::new();
-        let mut queries = Vec::new();
-
-        for _ in 0..100 {
-            let rr = arbitrary_resourcerecord();
-            cache.insert(&rr);
-            queries.push((
-                rr.name.clone(),
-                QueryType::Record(rr.rtype_with_data.rtype()),
-                QueryClass::Record(rr.rclass),
-            ));
-        }
-        for (name, qtype, qclass) in queries {
-            cache.get_without_checking_expiration(&name, &qtype, &qclass);
-        }
-
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_then_prune_maintains_invariants() {
-        let mut cache = Cache::with_desired_size(25);
-
-        for _ in 0..100 {
-            cache.insert(&arbitrary_resourcerecord());
-        }
-
-        assert_eq!(75, cache.prune());
-        assert_eq!(25, cache.current_size);
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_then_expire_maintains_invariants() {
-        let mut cache = Cache::new();
-
-        for i in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.ttl = if i > 0 && i % 2 == 0 { 0 } else { 300 };
-            cache.insert(&rr);
-        }
-
-        assert_eq!(49, cache.remove_expired());
-        assert_eq!(51, cache.current_size);
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_prune_expires_all() {
-        let mut cache = Cache::with_desired_size(99);
-
-        for i in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.ttl = if i > 0 && i % 2 == 0 { 0 } else { 300 };
-            cache.insert(&rr);
-        }
-
-        assert_eq!(49, cache.prune());
-    }
-
-    fn assert_invariants(cache: &Cache) {
-        assert_eq!(
-            cache.current_size,
-            cache.entries.values().map(|e| e.size).sum::<usize>()
-        );
-
-        assert_eq!(cache.entries.len(), cache.access_priority.len());
-        assert_eq!(cache.entries.len(), cache.expiry_priority.len());
-
-        let mut access_priority = PriorityQueue::new();
-        let mut expiry_priority = PriorityQueue::new();
-
-        for (name, entry) in cache.entries.iter() {
-            assert_eq!(
-                entry.size,
-                entry.records.values().map(|r| r.len()).sum::<usize>()
-            );
-
-            let mut min_expires = None;
-            for (rtype, tuples) in entry.records.iter() {
-                for (rtype_with_data, _, expires) in tuples {
-                    assert_eq!(*rtype, rtype_with_data.rtype());
-
-                    if let Some(e) = min_expires {
-                        if *expires < e {
-                            min_expires = Some(*expires);
-                        }
-                    } else {
-                        min_expires = Some(*expires);
-                    }
-                }
-            }
-
-            assert_eq!(Some(entry.next_expiry), min_expires);
-
-            access_priority.push(name.clone(), Reverse(entry.last_read));
-            expiry_priority.push(name.clone(), Reverse(entry.next_expiry));
-        }
-
-        assert_eq!(cache.access_priority, access_priority);
-        assert_eq!(cache.expiry_priority, expiry_priority);
     }
 }
 


### PR DESCRIPTION
This commit refactors the cache, pulling out a generic data
structure---the `NamespacedCache`---and implementing the resolver
cache in terms of it.

I think this is probably an improvement overall but the benchmark
results show a significant slowdown (15%+ regressions) and I'd like to
figure out why before merging this.