### PR TITLE
Drop support for non-IN record classes

### DIFF
--- a/benches/cache.rs
+++ b/benches/cache.rs
@@ -55,11 +55,7 @@ fn bench__get_without_checking_expiration__hit(c: &mut Criterion) {
                 || build_cache(size, rrs),
                 |mut cache| {
                     for (name, rtype) in &queries {
-                        cache.get_without_checking_expiration(
-                            name,
-                            &QueryType::Record(*rtype),
-                            &QueryClass::Record(RecordClass::IN),
-                        );
+                        cache.get_without_checking_expiration(name, &QueryType::Record(*rtype));
                     }
                 },
                 BatchSize::SmallInput,
@@ -74,17 +70,17 @@ fn bench__get_without_checking_expiration__miss(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_without_checking_expiration/miss");
     for size in [1, 100, 1000] {
         let (rrs, queries) = make_rrs(size, 0);
+        let name = DomainName::from_dotted_string(
+            "name.which.is.unlikely.to.coincidentally.be.randomly.generated",
+        )
+        .unwrap();
         group.throughput(Throughput::Elements(size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), &rrs, |b, rrs| {
             b.iter_batched(
                 || build_cache(size, rrs),
                 |mut cache| {
-                    for (name, rtype) in &queries {
-                        cache.get_without_checking_expiration(
-                            name,
-                            &QueryType::Record(*rtype),
-                            &QueryClass::Record(RecordClass::CH),
-                        );
+                    for (_, rtype) in &queries {
+                        cache.get_without_checking_expiration(&name, &QueryType::Record(*rtype));
                     }
                 },
                 BatchSize::SmallInput,

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -35,12 +35,7 @@ pub fn update_root_zone_from_hosts_data(zone: &mut Zone, data: &str) -> Result<(
     for line in data.lines() {
         if let Some((address, new_names)) = parse_line(line)? {
             for name in new_names {
-                zone.insert(
-                    &name,
-                    RecordTypeWithData::A { address },
-                    RecordClass::IN,
-                    300,
-                );
+                zone.insert(&name, RecordTypeWithData::A { address }, 300);
             }
         }
     }
@@ -171,7 +166,7 @@ mod tests {
                 Some(ZoneResult::Answer {
                     rrs: vec![a_record(name, *addr)]
                 }),
-                root_zone.resolve(&domain(name), QueryType::Wildcard, QueryClass::Wildcard)
+                root_zone.resolve(&domain(name), QueryType::Wildcard)
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,14 +226,12 @@ async fn main() {
                 root_zone.insert_wildcard(
                     &record.domain.name.domain,
                     RecordTypeWithData::A { address: *address },
-                    RecordClass::IN,
                     300,
                 );
             } else {
                 root_zone.insert(
                     &record.domain.name.domain,
                     RecordTypeWithData::A { address: *address },
-                    RecordClass::IN,
                     300,
                 );
             }
@@ -245,7 +243,6 @@ async fn main() {
                     RecordTypeWithData::CNAME {
                         cname: cname.domain.clone(),
                     },
-                    RecordClass::IN,
                     300,
                 );
             } else {
@@ -254,7 +251,6 @@ async fn main() {
                     RecordTypeWithData::CNAME {
                         cname: cname.domain.clone(),
                     },
-                    RecordClass::IN,
                     300,
                 );
             }
@@ -266,7 +262,6 @@ async fn main() {
                     RecordTypeWithData::NS {
                         nsdname: ns.domain.clone(),
                     },
-                    RecordClass::IN,
                     300,
                 );
             } else {
@@ -275,7 +270,6 @@ async fn main() {
                     RecordTypeWithData::NS {
                         nsdname: ns.domain.clone(),
                     },
-                    RecordClass::IN,
                     300,
                 );
             }

--- a/src/protocol/wire_types.rs
+++ b/src/protocol/wire_types.rs
@@ -951,9 +951,6 @@ impl<'a> arbitrary::Arbitrary<'a> for RecordType {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum RecordClass {
     IN,
-    CS,
-    CH,
-    HS,
     Unknown(RecordClassUnknown),
 }
 
@@ -979,9 +976,6 @@ impl From<u16> for RecordClass {
     fn from(value: u16) -> Self {
         match value {
             1 => RecordClass::IN,
-            2 => RecordClass::CS,
-            3 => RecordClass::CH,
-            4 => RecordClass::HS,
             _ => RecordClass::Unknown(RecordClassUnknown(value)),
         }
     }
@@ -991,9 +985,6 @@ impl From<RecordClass> for u16 {
     fn from(value: RecordClass) -> Self {
         match value {
             RecordClass::IN => 1,
-            RecordClass::CS => 2,
-            RecordClass::CH => 3,
-            RecordClass::HS => 4,
             RecordClass::Unknown(RecordClassUnknown(value)) => value,
         }
     }

--- a/src/resolver/rr_util.rs
+++ b/src/resolver/rr_util.rs
@@ -141,7 +141,7 @@ mod tests {
             follow_cnames(
                 &[a_record("www.example.net", Ipv4Addr::new(1, 1, 1, 1))],
                 &domain("www.example.com"),
-                &QueryClass::Record(RecordClass::CH),
+                &QueryClass::Record(u16::into(42)),
                 &QueryType::Wildcard
             )
         );

--- a/src/resolver/rr_util.rs
+++ b/src/resolver/rr_util.rs
@@ -9,18 +9,16 @@ use crate::protocol::wire_types::*;
 /// name that will have the non-`CNAME` records associated with it).
 ///
 /// Returns `None` if CNAMEs form a loop, or there is no RR which
-/// matches the target name (a CNAME or one with the right type &
-/// class).
+/// matches the target name (a CNAME or one with the right type).
 pub fn follow_cnames(
     rrs: &[ResourceRecord],
     target: &DomainName,
-    qclass: &QueryClass,
     qtype: &QueryType,
 ) -> Option<(DomainName, HashMap<DomainName, DomainName>)> {
     let mut got_match = false;
     let mut cname_map = HashMap::<DomainName, DomainName>::new();
     for rr in rrs {
-        if &rr.name == target && rr.rclass.matches(qclass) && rr.rtype_with_data.matches(qtype) {
+        if &rr.name == target && rr.rtype_with_data.matches(qtype) {
             got_match = true;
         }
         if let RecordTypeWithData::CNAME { cname } = &rr.rtype_with_data {
@@ -84,12 +82,7 @@ pub fn get_better_ns_names(
 /// `CNAME`s in the response and get the address from the final `A`
 /// record.
 pub fn get_ip(rrs: &[ResourceRecord], target: &DomainName) -> Option<Ipv4Addr> {
-    if let Some((final_name, _)) = follow_cnames(
-        rrs,
-        target,
-        &QueryClass::Record(RecordClass::IN),
-        &QueryType::Record(RecordType::A),
-    ) {
+    if let Some((final_name, _)) = follow_cnames(rrs, target, &QueryType::Record(RecordType::A)) {
         for rr in rrs {
             match &rr.rtype_with_data {
                 RecordTypeWithData::A { address } if rr.name == final_name => {
@@ -112,12 +105,7 @@ mod tests {
     fn follow_cnames_empty() {
         assert_eq!(
             None,
-            follow_cnames(
-                &[],
-                &domain("www.example.com"),
-                &QueryClass::Wildcard,
-                &QueryType::Wildcard
-            )
+            follow_cnames(&[], &domain("www.example.com"), &QueryType::Wildcard)
         );
     }
 
@@ -128,20 +116,6 @@ mod tests {
             follow_cnames(
                 &[a_record("www.example.net", Ipv4Addr::new(1, 1, 1, 1))],
                 &domain("www.example.com"),
-                &QueryClass::Wildcard,
-                &QueryType::Wildcard
-            )
-        );
-    }
-
-    #[test]
-    fn follow_cnames_no_class_match() {
-        assert_eq!(
-            None,
-            follow_cnames(
-                &[a_record("www.example.net", Ipv4Addr::new(1, 1, 1, 1))],
-                &domain("www.example.com"),
-                &QueryClass::Record(u16::into(42)),
                 &QueryType::Wildcard
             )
         );
@@ -154,7 +128,6 @@ mod tests {
             follow_cnames(
                 &[a_record("www.example.net", Ipv4Addr::new(1, 1, 1, 1))],
                 &domain("www.example.com"),
-                &QueryClass::Wildcard,
                 &QueryType::Record(RecordType::NS)
             )
         );
@@ -165,12 +138,7 @@ mod tests {
         let rr_a = a_record("www.example.com", Ipv4Addr::new(127, 0, 0, 1));
         assert_eq!(
             Some((domain("www.example.com"), HashMap::new())),
-            follow_cnames(
-                &[rr_a],
-                &domain("www.example.com"),
-                &QueryClass::Wildcard,
-                &QueryType::Wildcard
-            )
+            follow_cnames(&[rr_a], &domain("www.example.com"), &QueryType::Wildcard)
         );
     }
 
@@ -192,7 +160,6 @@ mod tests {
             follow_cnames(
                 &[rr_a, rr_cname2, rr_cname1],
                 &domain("www.example.com"),
-                &QueryClass::Wildcard,
                 &QueryType::Wildcard
             )
         );
@@ -208,7 +175,6 @@ mod tests {
             follow_cnames(
                 &[rr_cname1, rr_cname2],
                 &domain("www.example.com"),
-                &QueryClass::Wildcard,
                 &QueryType::Wildcard
             )
         )


### PR DESCRIPTION
Pretending to support these other classes just creates extra unnecessary work because (1) I don't have access to these other networks to test, and (2) I currently don't handle class-specific RDATA decoding, so the current implementation wouldn't work on such networks anyway.  So let's just get rid of them.

Closes #37 