### PR TITLE
Implement RFC 3596: DNS Extensions to Support IP Version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Supported standards
   Defines the wire format and discusses implementation concerns of the
   algorithms from RFC 1034.
 
+- [RFC 3596: DNS Extensions to Support IP Version 6](https://datatracker.ietf.org/doc/html/rfc3596)
+
+  Defines the `AAAA` record and query types.
+
 - [hosts(5)](https://man7.org/linux/man-pages/man5/hosts.5.html)
 
   Defines the Linux hosts file format.

--- a/config/hosts/99-example
+++ b/config/hosts/99-example
@@ -1,5 +1,5 @@
 # hosts can be blocked by routing them to 0.0.0.0
 0.0.0.0 block.test.barrucadu.co.uk
 
-# since resolved doesn't support AAAA records yet, IPv6 lines are ignored
-::1 ignored
+# ipv6 addresses are supported too
+::1:2:3:4 one-two-three-four.test.barrucadu.co.uk

--- a/src/protocol/deserialise.rs
+++ b/src/protocol/deserialise.rs
@@ -1,7 +1,7 @@
 //! Deserialisation of DNS messages from the network.  See the `types`
 //! module for details of the format.
 
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::protocol::types::*;
 
@@ -161,6 +161,18 @@ impl ResourceRecord {
             },
             RecordType::TXT => RecordTypeWithData::TXT {
                 octets: raw_rdata()?,
+            },
+            RecordType::AAAA => RecordTypeWithData::AAAA {
+                address: Ipv6Addr::new(
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                    buffer.next_u16().ok_or(Error::ResourceRecordTooShort(id))?,
+                ),
             },
             RecordType::Unknown(tag) => RecordTypeWithData::Unknown {
                 tag,

--- a/src/protocol/serialise.rs
+++ b/src/protocol/serialise.rs
@@ -161,6 +161,7 @@ impl ResourceRecord {
                 (RecordType::MX, octets)
             }
             RecordTypeWithData::TXT { octets } => (RecordType::TXT, octets),
+            RecordTypeWithData::AAAA { address } => (RecordType::AAAA, Vec::from(address.octets())),
             RecordTypeWithData::Unknown { tag, octets } => (RecordType::Unknown(tag), octets),
         };
 

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -1113,6 +1113,15 @@ pub mod test_util {
         }
     }
 
+    pub fn aaaa_record(name: &str, address: Ipv6Addr) -> ResourceRecord {
+        ResourceRecord {
+            name: domain(name),
+            rtype_with_data: RecordTypeWithData::AAAA { address },
+            rclass: RecordClass::IN,
+            ttl: 300,
+        }
+    }
+
     pub fn cname_record(name: &str, target_name: &str) -> ResourceRecord {
         ResourceRecord {
             name: domain(name),

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// Basic DNS message format, used for both queries and responses.
 ///
@@ -493,6 +493,15 @@ pub enum RecordTypeWithData {
     /// Where `TXT-DATA` is one or more character strings.
     TXT { octets: Vec<u8> },
 
+    /// ```text
+    ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+    ///     |                    ADDRESS                    |
+    ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+    /// ```
+    ///
+    /// Where `ADDRESS` is a 128 bit Internet address.
+    AAAA { address: Ipv6Addr },
+
     /// Any other record.
     Unknown {
         tag: RecordTypeUnknown,
@@ -527,6 +536,7 @@ impl RecordTypeWithData {
             RecordTypeWithData::MINFO { .. } => RecordType::MINFO,
             RecordTypeWithData::MX { .. } => RecordType::MX,
             RecordTypeWithData::TXT { .. } => RecordType::TXT,
+            RecordTypeWithData::AAAA { .. } => RecordType::AAAA,
             RecordTypeWithData::Unknown { tag, .. } => RecordType::Unknown(*tag),
         }
     }
@@ -590,6 +600,9 @@ impl<'a> arbitrary::Arbitrary<'a> for RecordTypeWithData {
                 exchange: u.arbitrary()?,
             },
             RecordType::TXT => RecordTypeWithData::TXT { octets },
+            RecordType::AAAA => RecordTypeWithData::AAAA {
+                address: u.arbitrary()?,
+            },
             RecordType::Unknown(tag) => RecordTypeWithData::Unknown { tag, octets },
         };
         Ok(rtype_with_data)
@@ -870,6 +883,7 @@ pub enum RecordType {
     MINFO,
     MX,
     TXT,
+    AAAA,
     Unknown(RecordTypeUnknown),
 }
 
@@ -911,6 +925,7 @@ impl From<u16> for RecordType {
             14 => RecordType::MINFO,
             15 => RecordType::MX,
             16 => RecordType::TXT,
+            28 => RecordType::AAAA,
             _ => RecordType::Unknown(RecordTypeUnknown(value)),
         }
     }
@@ -935,6 +950,7 @@ impl From<RecordType> for u16 {
             RecordType::MINFO => 14,
             RecordType::MX => 15,
             RecordType::TXT => 16,
+            RecordType::AAAA => 28,
             RecordType::Unknown(RecordTypeUnknown(value)) => value,
         }
     }


### PR DESCRIPTION
This PR adds support for `AAAA` / IPv6 address records to:

- DNS messages
- Hosts files
- Zone files

And updates the supported standards in the README.

Closes #50 