### PR TITLE
Add fuzz tests for zone format & fix issues

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,9 @@ name = "wire_serialise_round_trip"
 path = "fuzz_targets/wire_serialise_round_trip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "zone_deserialise_round_trip"
+path = "fuzz_targets/zone_deserialise_round_trip.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -37,3 +37,9 @@ name = "zone_deserialise_round_trip"
 path = "fuzz_targets/zone_deserialise_round_trip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "zone_serialise_round_trip"
+path = "fuzz_targets/zone_serialise_round_trip.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/zone_deserialise_round_trip.rs
+++ b/fuzz/fuzz_targets/zone_deserialise_round_trip.rs
@@ -1,0 +1,15 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use resolved::zones::types::Zone;
+
+fuzz_target!(|data: &str| {
+    if let Ok(deserialised) = Zone::deserialise(data) {
+        let serialised = deserialised.clone().serialise();
+        if let Ok(re_deserialised) = Zone::deserialise(&serialised) {
+            assert_eq!(deserialised, re_deserialised);
+        } else {
+            panic!("expected successful re-deserialisation");
+        }
+    }
+});

--- a/fuzz/fuzz_targets/zone_serialise_round_trip.rs
+++ b/fuzz/fuzz_targets/zone_serialise_round_trip.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use resolved::zones::types::Zone;
+
+fuzz_target!(|zone: Zone| {
+    let serialised = zone.serialise();
+    if let Ok(deserialised) = Zone::deserialise(&serialised) {
+        assert_eq!(zone, deserialised);
+    } else {
+        panic!("expected successful deserialisation");
+    }
+});

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -920,7 +920,7 @@ impl<'a> arbitrary::Arbitrary<'a> for DomainName {
             let bs = u.bytes(label_len.into())?;
             for b in bs {
                 let ascii_byte = if b.is_ascii() { *b } else { *b % 128 };
-                let octet = if ascii_byte == b'.' {
+                let octet = if ascii_byte == b'.' || ascii_byte == b'*' {
                     b'x'
                 } else {
                     ascii_byte.to_ascii_lowercase()
@@ -1305,7 +1305,7 @@ mod tests {
                 for _ in 0..label_len {
                     let mut chr = (32..126).fake::<u8>();
 
-                    if chr == b'.' {
+                    if chr == b'.' || chr == b'*' {
                         chr = b'X';
                     }
 

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -919,9 +919,14 @@ impl<'a> arbitrary::Arbitrary<'a> for DomainName {
             octets.push(label_len);
             let bs = u.bytes(label_len.into())?;
             for b in bs {
-                let o = if b.is_ascii() { *b } else { *b % 128 };
-                label.push(o.to_ascii_lowercase());
-                octets.push(o.to_ascii_lowercase());
+                let ascii_byte = if b.is_ascii() { *b } else { *b % 128 };
+                let octet = if ascii_byte == b'.' {
+                    b'x'
+                } else {
+                    ascii_byte.to_ascii_lowercase()
+                };
+                label.push(octet);
+                octets.push(octet);
             }
             labels.push(label);
         }
@@ -1300,9 +1305,8 @@ mod tests {
                 for _ in 0..label_len {
                     let mut chr = (32..126).fake::<u8>();
 
-                    // turn '.' to 'X'
-                    if chr == 46 {
-                        chr = 88;
+                    if chr == b'.' {
+                        chr = b'X';
                     }
 
                     label.push(chr);

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// Basic DNS message format, used for both queries and responses.
@@ -797,6 +798,10 @@ impl DomainName {
         }
     }
 
+    pub fn is_root(&self) -> bool {
+        self.octets.len() == 1 && self.labels.len() == 1
+    }
+
     pub fn is_subdomain_of(&self, other: &DomainName) -> bool {
         self.labels.ends_with(&other.labels)
     }
@@ -899,8 +904,8 @@ impl DomainName {
     }
 }
 
-impl std::fmt::Debug for DomainName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for DomainName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DomainName")
             .field("to_dotted_string()", &self.to_dotted_string())
             .finish()
@@ -1064,6 +1069,31 @@ impl RecordType {
             QueryType::Wildcard => true,
             QueryType::Record(rtype) => rtype == self,
             _ => false,
+        }
+    }
+}
+
+impl fmt::Display for RecordType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RecordType::A => write!(f, "A"),
+            RecordType::NS => write!(f, "NS"),
+            RecordType::MD => write!(f, "MD"),
+            RecordType::MF => write!(f, "MF"),
+            RecordType::CNAME => write!(f, "CNAME"),
+            RecordType::SOA => write!(f, "SOA"),
+            RecordType::MB => write!(f, "MB"),
+            RecordType::MG => write!(f, "MG"),
+            RecordType::MR => write!(f, "MR"),
+            RecordType::NULL => write!(f, "NULL"),
+            RecordType::WKS => write!(f, "WKS"),
+            RecordType::PTR => write!(f, "PTR"),
+            RecordType::HINFO => write!(f, "HINFO"),
+            RecordType::MINFO => write!(f, "MINFO"),
+            RecordType::MX => write!(f, "MX"),
+            RecordType::TXT => write!(f, "TXT"),
+            RecordType::AAAA => write!(f, "AAAA"),
+            RecordType::Unknown(RecordTypeUnknown(n)) => write!(f, "{}", n),
         }
     }
 }

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -920,7 +920,7 @@ impl<'a> arbitrary::Arbitrary<'a> for DomainName {
             let bs = u.bytes(label_len.into())?;
             for b in bs {
                 let ascii_byte = if b.is_ascii() { *b } else { *b % 128 };
-                let octet = if ascii_byte == b'.' || ascii_byte == b'*' {
+                let octet = if ascii_byte == b'.' || ascii_byte == b'*' || ascii_byte == b'@' {
                     b'x'
                 } else {
                     ascii_byte.to_ascii_lowercase()
@@ -1305,7 +1305,7 @@ mod tests {
                 for _ in 0..label_len {
                     let mut chr = (32..126).fake::<u8>();
 
-                    if chr == b'.' || chr == b'*' {
+                    if chr == b'.' || chr == b'*' || chr == b'@' {
                         chr = b'X';
                     }
 

--- a/src/zones/deserialise.rs
+++ b/src/zones/deserialise.rs
@@ -504,7 +504,9 @@ fn parse_domain_or_wildcard(
     let dotted_string_vec = dotted_string.chars().collect::<Vec<char>>();
 
     if dotted_string_vec.is_empty() {
-        panic!("reached parse_domain_or_wildcard with an empty string");
+        return Err(Error::ExpectedDomainName {
+            dotted_string: dotted_string.to_string(),
+        });
     }
 
     if dotted_string == "*" {
@@ -534,7 +536,9 @@ fn parse_domain(origin: &Option<DomainName>, dotted_string: &str) -> Result<Doma
     let dotted_string_vec = dotted_string.chars().collect::<Vec<char>>();
 
     if dotted_string_vec.is_empty() {
-        panic!("reached parse_domain with an empty string");
+        return Err(Error::ExpectedDomainName {
+            dotted_string: dotted_string.to_string(),
+        });
     }
 
     if dotted_string == "@" {
@@ -713,11 +717,9 @@ fn tokenise_entry<I: Iterator<Item = char>>(
             (State::SkipToEndOfComment, _) => State::SkipToEndOfComment,
 
             (State::QuotedString, '"') => {
-                if !token_string.is_empty() {
-                    tokens.push((token_string, token_octets));
-                    token_string = String::new();
-                    token_octets = Vec::new();
-                }
+                tokens.push((token_string, token_octets));
+                token_string = String::new();
+                token_octets = Vec::new();
                 State::Initial
             }
             (State::QuotedString, '\\') => {

--- a/src/zones/deserialise.rs
+++ b/src/zones/deserialise.rs
@@ -508,7 +508,11 @@ fn parse_domain_or_wildcard(
         && dotted_string_vec[0] == '*'
         && dotted_string_vec[1] == '.'
     {
-        let name = parse_domain(origin, &dotted_string_vec[2..].iter().collect::<String>())?;
+        let name = if dotted_string_vec.len() == 2 {
+            DomainName::root_domain()
+        } else {
+            parse_domain(origin, &dotted_string_vec[2..].iter().collect::<String>())?
+        };
         Ok(MaybeWildcard::Wildcard { name })
     } else {
         let name = parse_domain(origin, dotted_string)?;
@@ -1616,6 +1620,20 @@ mod tests {
             assert_eq!(
                 MaybeWildcard::Wildcard {
                     name: domain("example.com.")
+                },
+                name
+            );
+        } else {
+            panic!("expected parse");
+        }
+    }
+
+    #[test]
+    fn parse_domain_or_wildcard_wildcard_root() {
+        if let Ok(name) = parse_domain_or_wildcard(&None, "*.") {
+            assert_eq!(
+                MaybeWildcard::Wildcard {
+                    name: DomainName::root_domain()
                 },
                 name
             );

--- a/src/zones/mod.rs
+++ b/src/zones/mod.rs
@@ -1,2 +1,3 @@
 pub mod deserialise;
+pub mod serialise;
 pub mod types;

--- a/src/zones/serialise.rs
+++ b/src/zones/serialise.rs
@@ -1,0 +1,200 @@
+use std::collections::HashSet;
+
+use crate::protocol::types::*;
+use crate::zones::types::*;
+
+impl Zone {
+    pub fn serialise(&self) -> String {
+        let mut out = String::new();
+
+        if let Some(soa) = self.get_soa() {
+            let show_origin = !self.get_apex().is_root();
+            let serialised_apex = serialise_octets(
+                &self
+                    .get_apex()
+                    .to_dotted_string()
+                    .bytes()
+                    .collect::<Vec<u8>>(),
+                false,
+            );
+
+            if show_origin {
+                out.push_str(&format!("$ORIGIN {}\n\n", serialised_apex))
+            }
+
+            out.push_str(&format!(
+                "{} IN SOA {} {} {} {} {} {} {}\n\n",
+                if show_origin { "@" } else { &serialised_apex },
+                self.serialise_domain(&soa.mname),
+                self.serialise_domain(&soa.rname),
+                soa.serial,
+                soa.refresh,
+                soa.retry,
+                soa.expire,
+                soa.minimum
+            ));
+        }
+
+        let all_records = self.all_records();
+        let all_wildcard_records = self.all_wildcard_records();
+
+        let sorted_domains = {
+            let mut set = HashSet::new();
+            for name in all_records.keys() {
+                set.insert(*name);
+            }
+            for name in all_wildcard_records.keys() {
+                set.insert(*name);
+            }
+            let mut vec = set.into_iter().collect::<Vec<&DomainName>>();
+            vec.sort();
+            vec
+        };
+
+        for domain in sorted_domains {
+            if let Some(zrs) = all_records.get(domain) {
+                let has_wildcards = all_wildcard_records.contains_key(domain);
+                for zr in zrs {
+                    if zr.rtype_with_data.rtype() == RecordType::SOA {
+                        // already handled above, and it's invalid for
+                        // a zone to have multiple SOA records
+                        continue;
+                    }
+
+                    out.push_str(&format!(
+                        "{}{} {} IN {} {}\n",
+                        self.serialise_domain(domain),
+                        if has_wildcards { "  " } else { "" },
+                        zr.ttl,
+                        zr.rtype_with_data.rtype(),
+                        self.serialise_rdata(&zr.rtype_with_data)
+                    ));
+                }
+            }
+            if let Some(zrs) = all_wildcard_records.get(domain) {
+                for zr in zrs {
+                    out.push_str(&format!(
+                        "*.{} {} IN {} {}\n",
+                        self.serialise_domain(domain),
+                        zr.ttl,
+                        zr.rtype_with_data.rtype(),
+                        self.serialise_rdata(&zr.rtype_with_data)
+                    ));
+                }
+            }
+            out.push('\n');
+        }
+
+        out
+    }
+
+    /// Serialise a domain name: dotted string format, with the apex
+    /// chopped off if this is an authoritative zone (unless the apex
+    /// is the root domain, because that's only a single character
+    /// long so we may as well show it).
+    fn serialise_domain(&self, name: &DomainName) -> String {
+        let domain_str = {
+            let apex = self.get_apex();
+            if apex.is_root() || !self.is_authoritative() || !name.is_subdomain_of(apex) {
+                name.to_dotted_string()
+            } else if name == apex {
+                "@".to_string()
+            } else {
+                let mut stripped = name.clone();
+                for _ in 0..apex.labels.len() {
+                    stripped.labels.pop();
+                }
+                for _ in 0..apex.octets.len() {
+                    stripped.octets.pop();
+                }
+                stripped.to_dotted_string()
+            }
+        };
+
+        serialise_octets(&domain_str.bytes().collect::<Vec<u8>>(), false)
+    }
+
+    /// Serialise the RDATA
+    fn serialise_rdata(&self, rtype_with_data: &RecordTypeWithData) -> String {
+        match rtype_with_data {
+            RecordTypeWithData::A { address } => format!("{}", address),
+            RecordTypeWithData::NS { nsdname } => self.serialise_domain(nsdname),
+            RecordTypeWithData::MD { madname } => self.serialise_domain(madname),
+            RecordTypeWithData::MF { madname } => self.serialise_domain(madname),
+            RecordTypeWithData::CNAME { cname } => self.serialise_domain(cname),
+            RecordTypeWithData::SOA { .. } => panic!("unexpected SOA"),
+            RecordTypeWithData::MB { madname } => self.serialise_domain(madname),
+            RecordTypeWithData::MG { mdmname } => self.serialise_domain(mdmname),
+            RecordTypeWithData::MR { newname } => self.serialise_domain(newname),
+            RecordTypeWithData::NULL { octets } => serialise_octets(octets, true),
+            RecordTypeWithData::WKS { octets } => serialise_octets(octets, true),
+            RecordTypeWithData::PTR { ptrdname } => self.serialise_domain(ptrdname),
+            RecordTypeWithData::HINFO { octets } => serialise_octets(octets, true),
+            RecordTypeWithData::MINFO { rmailbx, emailbx } => format!(
+                "{} {}",
+                self.serialise_domain(rmailbx),
+                self.serialise_domain(emailbx)
+            ),
+            RecordTypeWithData::MX {
+                preference,
+                exchange,
+            } => format!("{} {}", preference, self.serialise_domain(exchange)),
+            RecordTypeWithData::TXT { octets } => serialise_octets(octets, true),
+            RecordTypeWithData::AAAA { address } => format!("{}", address),
+            RecordTypeWithData::Unknown { octets, .. } => serialise_octets(octets, true),
+        }
+    }
+}
+
+/// Serialise a string of octets to a quoted or unquoted string with
+/// the appropriate escaping.
+fn serialise_octets(octets: &[u8], quoted: bool) -> String {
+    let mut out = String::with_capacity(2 + octets.len());
+
+    if quoted {
+        out.push('"');
+    }
+
+    for octet in octets {
+        if *octet == b'"' || *octet == b'\\' || *octet == b';' || *octet == b'(' || *octet == b')' {
+            out.push('\\');
+            out.push(*octet as char);
+        } else if *octet < 32 || *octet > 126 || (*octet == 32 && !quoted) {
+            out.push('\\');
+            let digit3 = *octet % 10;
+            let digit2 = (*octet / 10) % 10;
+            let digit1 = (*octet / 100) % 10;
+            out.push((digit1 + 48) as char);
+            out.push((digit2 + 48) as char);
+            out.push((digit3 + 48) as char);
+        } else {
+            out.push(*octet as char);
+        }
+    }
+
+    if quoted {
+        out.push('"');
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialise_octets_special() {
+        assert_eq!("\\012", serialise_octets(&[12], false));
+        assert_eq!("\\234", serialise_octets(&[234], false));
+
+        assert_eq!("\\\\", serialise_octets(&[b'\\'], false));
+        assert_eq!("\\\"", serialise_octets(&[b'"'], false));
+    }
+
+    #[test]
+    fn serialise_octets_space() {
+        assert_eq!("\\032", serialise_octets(&[b' '], false));
+        assert_eq!("\" \"", serialise_octets(&[b' '], true));
+    }
+}

--- a/src/zones/types.rs
+++ b/src/zones/types.rs
@@ -105,6 +105,11 @@ impl Zone {
         &self.apex
     }
 
+    /// Return the SOA if the zone is authoritative.
+    pub fn get_soa(&self) -> &Option<SOA> {
+        &self.soa
+    }
+
     /// Returns true if the zone is authoritative.
     pub fn is_authoritative(&self) -> bool {
         self.soa.is_some()
@@ -469,8 +474,8 @@ impl SOA {
 /// A single record
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZoneRecord {
-    rtype_with_data: RecordTypeWithData,
-    ttl: u32,
+    pub rtype_with_data: RecordTypeWithData,
+    pub ttl: u32,
 }
 
 impl ZoneRecord {


### PR DESCRIPTION
This PR also implements a basic zone file serialiser, so that the fuzz tests can test the round-trip journey for simplicity (rather than essentially implementing a second zone file parser to compare the primary one too).