### PR TITLE
Implement reloading configuration on SIGUSR1 (also fixes memory leak / performance issue)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +800,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ any syntactically valid file as input, and output it in a consistent
 format regardless of how the input is structured.  So `htoh` and
 `ztoz` can be used to normalise existing files.
 
+**Signals:**
+
+- `SIGUSR1` - reload the configuration
+
 
 Development
 -----------

--- a/bin-resolved/Cargo.toml
+++ b/bin-resolved/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "3", features = ["derive"] }
 dns-types = { path = "../lib-dns-types" }
 priority-queue = "1"
 rand = "0.8.5"
-tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "io-util", "sync", "fs", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "io-util", "signal", "sync", "fs", "time"] }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/lib-dns-types/src/hosts/deserialise.rs
+++ b/lib-dns-types/src/hosts/deserialise.rs
@@ -151,19 +151,19 @@ mod tests {
         let expected_aaaa_records = &[("localhost.", Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
 
         for (name, addr) in expected_a_records {
+            let mut rr = a_record(name, *addr);
+            rr.ttl = TTL;
             assert_eq!(
-                Some(ZoneResult::Answer {
-                    rrs: vec![a_record(name, *addr)]
-                }),
+                Some(ZoneResult::Answer { rrs: vec![rr] }),
                 Zone::from(hosts.clone()).resolve(&domain(name), QueryType::Record(RecordType::A))
             );
         }
 
         for (name, addr) in expected_aaaa_records {
+            let mut rr = aaaa_record(name, *addr);
+            rr.ttl = TTL;
             assert_eq!(
-                Some(ZoneResult::Answer {
-                    rrs: vec![aaaa_record(name, *addr)]
-                }),
+                Some(ZoneResult::Answer { rrs: vec![rr] }),
                 Zone::from(hosts.clone())
                     .resolve(&domain(name), QueryType::Record(RecordType::AAAA))
             );

--- a/lib-dns-types/src/hosts/types.rs
+++ b/lib-dns-types/src/hosts/types.rs
@@ -4,6 +4,9 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use crate::protocol::types::*;
 use crate::zones::types::*;
 
+/// TTL used when converting into A / AAAA records.
+pub const TTL: u32 = 5;
+
 /// A collection of A records.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
@@ -65,10 +68,10 @@ impl From<Hosts> for Zone {
     fn from(hosts: Hosts) -> Zone {
         let mut zone = Self::default();
         for (name, address) in hosts.v4.into_iter() {
-            zone.insert(&name, RecordTypeWithData::A { address }, 300);
+            zone.insert(&name, RecordTypeWithData::A { address }, TTL);
         }
         for (name, address) in hosts.v6.into_iter() {
-            zone.insert(&name, RecordTypeWithData::AAAA { address }, 300);
+            zone.insert(&name, RecordTypeWithData::AAAA { address }, TTL);
         }
         zone
     }


### PR DESCRIPTION
This PR moves the `Zones` into a shared `RwLock`, removing the need to clone them for each request.  That solves the performance issue with large zones, and also a memory leak I'd not previously noticed (turns out copying zones over and over again uses up a lot of space).  And with the `Zones` in some shared mutable state, it's simple enough to implement reloading the configuration when a signal is received.