### PR TITLE
Make cache size configurable

### DIFF
--- a/bin-resolved/src/main.rs
+++ b/bin-resolved/src/main.rs
@@ -320,6 +320,10 @@ struct Args {
     #[clap(short, long, default_value_t = Ipv4Addr::UNSPECIFIED)]
     interface: Ipv4Addr,
 
+    /// How many records to hold in the cache
+    #[clap(short = 's', long, default_value_t = 512)]
+    cache_size: usize,
+
     /// Path to a hosts file, can be specified more than once
     #[clap(short = 'a', long)]
     hosts_file: Vec<PathBuf>,
@@ -365,7 +369,7 @@ async fn main() {
     };
 
     let zones_lock = Arc::new(RwLock::new(zones));
-    let cache = SharedCache::new();
+    let cache = SharedCache::with_desired_size(std::cmp::max(1, args.cache_size));
 
     tokio::spawn(listen_tcp(zones_lock.clone(), cache.clone(), tcp));
     tokio::spawn(listen_udp(zones_lock.clone(), cache.clone(), udp));

--- a/bin-resolved/src/resolver/cache.rs
+++ b/bin-resolved/src/resolver/cache.rs
@@ -72,6 +72,10 @@ impl SharedCache {
             let mut cache = self.cache.lock().expect(MUTEX_POISON_MESSAGE);
             cache.insert(record);
             if cache.current_size > cache.desired_size {
+                println!(
+                    "[CACHE] current {:?} greater than desired {:?}, pruning",
+                    cache.current_size, cache.desired_size
+                );
                 cache.prune();
             }
         }

--- a/bin-resolved/src/resolver/cache.rs
+++ b/bin-resolved/src/resolver/cache.rs
@@ -27,6 +27,13 @@ impl SharedCache {
         }
     }
 
+    /// Create a new cache with the given desired size.
+    pub fn with_desired_size(desired_size: usize) -> Self {
+        SharedCache {
+            cache: Arc::new(Mutex::new(Cache::with_desired_size(desired_size))),
+        }
+    }
+
     /// Get an entry from the cache.
     ///
     /// The TTL in the returned `ResourceRecord` is relative to the


### PR DESCRIPTION
If 0, an invalid size, is passed, 1 is used instead.  But it's unlikely that anything will work with a cache of size 1, due to #12 .

Closes #66 