### PR TITLE
Add a forwarding resolver

### DIFF
--- a/bin-resolved/src/resolver/forwarding.rs
+++ b/bin-resolved/src/resolver/forwarding.rs
@@ -1,0 +1,160 @@
+use async_recursion::async_recursion;
+use rand::Rng;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use tokio::time::timeout;
+
+use dns_types::protocol::types::*;
+use dns_types::zones::types::*;
+
+use super::cache::SharedCache;
+use super::nonrecursive::resolve_nonrecursive;
+use super::util::*;
+
+/// Forwarding DNS resolution.
+///
+/// Attempts to resolve a query locally and, if it cannot, calls out
+/// to another nameserver and returns its response.  As this other
+/// nameserver can spoof any records it wants, very little validation
+/// is done of its responses.
+///
+/// This has a 60s timeout.
+pub async fn resolve_forwarding(
+    recursion_limit: usize,
+    forward_address: Ipv4Addr,
+    zones: &Zones,
+    cache: &SharedCache,
+    question: &Question,
+) -> Option<ResolvedRecord> {
+    match timeout(
+        Duration::from_secs(60),
+        resolve_forwarding_notimeout(recursion_limit, forward_address, zones, cache, question),
+    )
+    .await
+    {
+        Ok(res) => res,
+        Err(_) => None,
+    }
+}
+
+/// Timeout-less version of `resolve_forwarding`.
+#[async_recursion]
+async fn resolve_forwarding_notimeout(
+    recursion_limit: usize,
+    forward_address: Ipv4Addr,
+    zones: &Zones,
+    cache: &SharedCache,
+    question: &Question,
+) -> Option<ResolvedRecord> {
+    if recursion_limit == 0 {
+        return None;
+    }
+
+    let mut combined_rrs = Vec::new();
+
+    match resolve_nonrecursive(recursion_limit - 1, zones, cache, question) {
+        Some(Ok(NameserverResponse::Answer {
+            rrs,
+            authority_rrs,
+            is_authoritative,
+        })) => {
+            if is_authoritative || question.qtype != QueryType::Wildcard {
+                println!("[DEBUG] got response to current query (non-recursive)");
+                return Some(
+                    NameserverResponse::Answer {
+                        rrs,
+                        authority_rrs,
+                        is_authoritative,
+                    }
+                    .into(),
+                );
+            } else {
+                println!("[DEBUG] got non-authoritative response to current wildcard query - continuing (non-recursive)");
+                combined_rrs = rrs;
+            }
+        }
+        Some(Ok(NameserverResponse::Delegation { .. })) => {
+            println!("[DEBUG] found better nameserver - ignoring in favour of forwarding nameserver (non-recursive)");
+        }
+        Some(Ok(NameserverResponse::CNAME { rrs, cname, .. })) => {
+            let cname_question = Question {
+                name: cname,
+                qclass: question.qclass,
+                qtype: question.qtype,
+            };
+            println!(
+                "[DEBUG] current query is a CNAME - restarting with CNAME target (non-recursive)"
+            );
+            if let Some(resolved) = resolve_forwarding_notimeout(
+                recursion_limit - 1,
+                forward_address,
+                zones,
+                cache,
+                &cname_question,
+            )
+            .await
+            {
+                let mut r_rrs = resolved.rrs();
+                let mut combined_rrs = Vec::with_capacity(rrs.len() + r_rrs.len());
+                combined_rrs.append(&mut rrs.clone());
+                combined_rrs.append(&mut r_rrs);
+                return Some(ResolvedRecord::NonAuthoritative { rrs: combined_rrs });
+            } else {
+                return None;
+            }
+        }
+        Some(Err(error)) => {
+            println!("[DEBUG] got error response to current query (non-recursive)");
+            return Some(error.into());
+        }
+        None => (),
+    }
+
+    if let Some(rrs) = query_nameserver(forward_address, question).await {
+        for rr in &rrs {
+            cache.insert(rr);
+        }
+        println!("[DEBUG] got response to current query (forwarding)");
+        prioritising_merge(&mut combined_rrs, rrs);
+        Some(ResolvedRecord::NonAuthoritative { rrs: combined_rrs })
+    } else {
+        None
+    }
+}
+/// Query a remote nameserver to answer a question.
+///
+/// This does a recursive query.
+async fn query_nameserver(address: Ipv4Addr, question: &Question) -> Option<Vec<ResourceRecord>> {
+    let mut request = Message::from_question(rand::thread_rng().gen(), question.clone());
+    request.header.recursion_desired = true;
+
+    println!(
+        "[DEBUG] forward query to nameserver for {:?} {:?} {:?}",
+        question.name.to_dotted_string(),
+        question.qclass,
+        question.qtype
+    );
+
+    match request.clone().to_octets() {
+        Ok(mut serialised_request) => {
+            if let Some(response) = query_nameserver_udp(address, &mut serialised_request).await {
+                if response_matches_request(&request, &response) {
+                    return Some(response.answers);
+                }
+            }
+            if let Some(response) = query_nameserver_tcp(address, &mut serialised_request).await {
+                if response_matches_request(&request, &response) {
+                    return Some(response.answers);
+                }
+            }
+            None
+        }
+        Err(err) => {
+            println!(
+                "[INTERNAL ERROR] could not serialise message {:?} \"{:?}\"",
+                request, err
+            );
+            None
+        }
+    }
+}

--- a/bin-resolved/src/resolver/mod.rs
+++ b/bin-resolved/src/resolver/mod.rs
@@ -1,12 +1,16 @@
 pub mod cache;
+pub mod forwarding;
 pub mod nonrecursive;
 pub mod recursive;
 pub mod util;
+
+use std::net::Ipv4Addr;
 
 use dns_types::protocol::types::Question;
 use dns_types::zones::types::Zones;
 
 use self::cache::SharedCache;
+use self::forwarding::resolve_forwarding;
 use self::nonrecursive::resolve_nonrecursive;
 use self::recursive::resolve_recursive;
 use self::util::ResolvedRecord;
@@ -22,12 +26,17 @@ pub const RECURSION_LIMIT: usize = 32;
 /// Resolve a question using the standard DNS algorithms.
 pub async fn resolve(
     is_recursive: bool,
+    forward_address: Option<Ipv4Addr>,
     zones: &Zones,
     cache: &SharedCache,
     question: &Question,
 ) -> Option<ResolvedRecord> {
     if is_recursive {
-        resolve_recursive(RECURSION_LIMIT, zones, cache, question).await
+        if let Some(address) = forward_address {
+            resolve_forwarding(RECURSION_LIMIT, address, zones, cache, question).await
+        } else {
+            resolve_recursive(RECURSION_LIMIT, zones, cache, question).await
+        }
     } else {
         resolve_nonrecursive(RECURSION_LIMIT, zones, cache, question).map(ResolvedRecord::from)
     }

--- a/bin-resolved/src/resolver/util.rs
+++ b/bin-resolved/src/resolver/util.rs
@@ -1,8 +1,13 @@
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
+use std::time::Duration;
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::time::timeout;
 
 use dns_types::protocol::types::*;
+
+use crate::net_util::{read_tcp_bytes, send_tcp_bytes, send_udp_bytes};
 
 /// The result of a name resolution attempt.
 ///
@@ -255,11 +260,204 @@ pub fn prioritising_merge(priority: &mut Vec<ResourceRecord>, new: Vec<ResourceR
     }
 }
 
+/// Send a message to a remote nameserver over UDP, returning the
+/// response.  If the message would be truncated, or an error occurs
+/// while sending it, `None` is returned.  Otherwise the deserialised
+/// response message is: but this response is NOT validated -
+/// consumers MUST validate the response before using it!
+///
+/// This has a 5s timeout.
+pub async fn query_nameserver_udp(
+    address: Ipv4Addr,
+    serialised_request: &mut [u8],
+) -> Option<Message> {
+    match timeout(
+        Duration::from_secs(5),
+        query_nameserver_udp_notimeout(address, serialised_request),
+    )
+    .await
+    {
+        Ok(res) => res,
+        Err(_) => None,
+    }
+}
+
+/// Timeout-less version of `query_nameserver_udp`.
+async fn query_nameserver_udp_notimeout(
+    address: Ipv4Addr,
+    serialised_request: &mut [u8],
+) -> Option<Message> {
+    if serialised_request.len() > 512 {
+        return None;
+    }
+
+    let mut buf = vec![0u8; 512];
+    match UdpSocket::bind("0.0.0.0:0").await {
+        Ok(sock) => match sock.connect((address, 53)).await {
+            Ok(_) => match send_udp_bytes(&sock, serialised_request).await {
+                Ok(_) => match sock.recv(&mut buf).await {
+                    Ok(_) => match Message::from_octets(&buf) {
+                        Ok(response) => Some(response),
+                        _ => None,
+                    },
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Send a message to a remote nameserver over TCP, returning the
+/// response.  This has the same return value caveats as
+/// `query_nameserver_udp`.
+///
+/// This has a 5s timeout.
+pub async fn query_nameserver_tcp(
+    address: Ipv4Addr,
+    serialised_request: &mut [u8],
+) -> Option<Message> {
+    match timeout(
+        Duration::from_secs(5),
+        query_nameserver_tcp_notimeout(address, serialised_request),
+    )
+    .await
+    {
+        Ok(res) => res,
+        Err(_) => None,
+    }
+}
+
+/// Timeout-less version of `query_nameserver_tcp`.
+async fn query_nameserver_tcp_notimeout(
+    address: Ipv4Addr,
+    serialised_request: &mut [u8],
+) -> Option<Message> {
+    match TcpStream::connect((address, 53)).await {
+        Ok(mut stream) => match send_tcp_bytes(&mut stream, serialised_request).await {
+            Ok(_) => match read_tcp_bytes(&mut stream).await {
+                Ok(bytes) => match Message::from_octets(bytes.as_ref()) {
+                    Ok(response) => Some(response),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Very basic validation that a nameserver response matches a
+/// message:
+///
+/// - Check the ID, opcode, and questions match the question.
+///
+/// - Check it is a response and no error is signalled.
+///
+/// - Check it is not truncated.
+pub fn response_matches_request(request: &Message, response: &Message) -> bool {
+    if request.header.id != response.header.id {
+        return false;
+    }
+    if !response.header.is_response {
+        return false;
+    }
+    if request.header.opcode != response.header.opcode {
+        return false;
+    }
+    if response.header.is_truncated {
+        return false;
+    }
+    if response.header.rcode != Rcode::NoError {
+        return false;
+    }
+    if request.questions != response.questions {
+        return false;
+    }
+
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use dns_types::protocol::types::test_util::*;
 
+    use super::test_util::*;
     use super::*;
+
+    #[test]
+    fn response_matches_request_accepts() {
+        let (request, response) = matching_nameserver_response();
+
+        assert!(response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_checks_id() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.id += 1;
+
+        assert!(!response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_checks_qr() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.is_response = false;
+
+        assert!(!response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_checks_opcode() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.opcode = Opcode::Status;
+
+        assert!(!response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_does_not_check_aa() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.is_authoritative = !response.header.is_authoritative;
+
+        assert!(response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_checks_tc() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.is_truncated = true;
+
+        assert!(!response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_does_not_check_rd() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.recursion_desired = !response.header.recursion_desired;
+
+        assert!(response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_does_not_check_ra() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.recursion_available = !response.header.recursion_available;
+
+        assert!(response_matches_request(&request, &response));
+    }
+
+    #[test]
+    fn response_matches_request_checks_rcode() {
+        let (request, mut response) = matching_nameserver_response();
+        response.header.rcode = Rcode::ServerFailure;
+
+        assert!(!response_matches_request(&request, &response));
+    }
 
     #[test]
     fn follow_cnames_empty() {
@@ -447,6 +645,38 @@ pub mod test_util {
     use std::net::Ipv4Addr;
 
     use super::*;
+
+    pub fn matching_nameserver_response() -> (Message, Message) {
+        nameserver_response(
+            "www.example.com.",
+            &[a_record("www.example.com.", Ipv4Addr::new(1, 1, 1, 1))],
+            &[],
+            &[],
+        )
+    }
+
+    pub fn nameserver_response(
+        name: &str,
+        answers: &[ResourceRecord],
+        authority: &[ResourceRecord],
+        additional: &[ResourceRecord],
+    ) -> (Message, Message) {
+        let request = Message::from_question(
+            1234,
+            Question {
+                name: domain(name),
+                qtype: QueryType::Record(RecordType::A),
+                qclass: QueryClass::Record(RecordClass::IN),
+            },
+        );
+
+        let mut response = request.make_response();
+        response.answers = answers.into();
+        response.authority = authority.into();
+        response.additional = additional.into();
+
+        (request, response)
+    }
 
     pub fn zones() -> Zones {
         let mut zone_na = Zone::default();


### PR DESCRIPTION
If the `--forward-address` argument is given, recursive queries which
can't be answered locally are sent to that, and the answer RRs
returned.  Non-recursive queries are still answered locally.

Closes #49