### PR TITLE
Fix Cloudflare ignoring queries - do not set RA flag in queries

### DIFF
--- a/lib-dns-types/src/protocol/types.rs
+++ b/lib-dns-types/src/protocol/types.rs
@@ -76,7 +76,7 @@ impl Message {
                 is_authoritative: false,
                 is_truncated: false,
                 recursion_desired: false,
-                recursion_available: true,
+                recursion_available: false,
                 rcode: Rcode::NoError,
             },
             questions: vec![question],


### PR DESCRIPTION
I don't think this flag has any meaning in queries, RFC 1035 only
says:

> Recursion Available - this be is set or cleared in a response, and
> denotes whether recursive query support is available in the name
> server.

It doesn't really make sense in a query, but it certainly doesn't
sound invalid.  And yet, with this set, Cloudflare drops the query
without even sending an error response.

Closes #72