### PR TITLE
Add RFC 3597-compliant `Display` and `FromStr` instances to `RecordClass` and `RecordType`

### DIFF
--- a/lib-dns-types/src/protocol/types.rs
+++ b/lib-dns-types/src/protocol/types.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::slice::Iter;
+use std::str::FromStr;
 
 /// Maximum encoded length of a domain name.  The number of labels
 /// plus sum of the lengths of the labels.
@@ -1200,9 +1201,54 @@ impl fmt::Display for RecordType {
             RecordType::TXT => write!(f, "TXT"),
             RecordType::AAAA => write!(f, "AAAA"),
             RecordType::SRV => write!(f, "SRV"),
-            RecordType::Unknown(RecordTypeUnknown(n)) => write!(f, "{}", n),
+            RecordType::Unknown(RecordTypeUnknown(n)) => write!(f, "TYPE{}", n),
         }
     }
+}
+
+impl FromStr for RecordType {
+    type Err = RecordTypeFromStr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "A" => Ok(RecordType::A),
+            "NS" => Ok(RecordType::NS),
+            "MD" => Ok(RecordType::MD),
+            "MF" => Ok(RecordType::MF),
+            "CNAME" => Ok(RecordType::CNAME),
+            "SOA" => Ok(RecordType::SOA),
+            "MB" => Ok(RecordType::MB),
+            "MG" => Ok(RecordType::MG),
+            "MR" => Ok(RecordType::MR),
+            "NULL" => Ok(RecordType::NULL),
+            "WKS" => Ok(RecordType::WKS),
+            "PTR" => Ok(RecordType::PTR),
+            "HINFO" => Ok(RecordType::HINFO),
+            "MINFO" => Ok(RecordType::MINFO),
+            "MX" => Ok(RecordType::MX),
+            "TXT" => Ok(RecordType::TXT),
+            "AAAA" => Ok(RecordType::AAAA),
+            "SRV" => Ok(RecordType::SRV),
+            _ => {
+                if let Some(type_str) = s.strip_prefix("TYPE") {
+                    if let Ok(type_num) = u16::from_str(type_str) {
+                        Ok(RecordType::from(type_num))
+                    } else {
+                        Err(RecordTypeFromStr::BadType)
+                    }
+                } else {
+                    Err(RecordTypeFromStr::NoParse)
+                }
+            }
+        }
+    }
+}
+
+/// Errors that can arise when converting a `&str` into a `RecordType`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum RecordTypeFromStr {
+    BadType,
+    NoParse,
 }
 
 impl From<u16> for RecordType {

--- a/lib-dns-types/src/protocol/types.rs
+++ b/lib-dns-types/src/protocol/types.rs
@@ -1335,6 +1335,43 @@ impl RecordClass {
     }
 }
 
+impl fmt::Display for RecordClass {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RecordClass::IN => write!(f, "IN"),
+            RecordClass::Unknown(RecordClassUnknown(n)) => write!(f, "CLASS{}", n),
+        }
+    }
+}
+
+impl FromStr for RecordClass {
+    type Err = RecordClassFromStr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "IN" => Ok(RecordClass::IN),
+            _ => {
+                if let Some(class_str) = s.strip_prefix("CLASS") {
+                    if let Ok(class_num) = u16::from_str(class_str) {
+                        Ok(RecordClass::from(class_num))
+                    } else {
+                        Err(RecordClassFromStr::BadClass)
+                    }
+                } else {
+                    Err(RecordClassFromStr::NoParse)
+                }
+            }
+        }
+    }
+}
+
+/// Errors that can arise when converting a `&str` into a `RecordClass`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum RecordClassFromStr {
+    BadClass,
+    NoParse,
+}
+
 impl From<u16> for RecordClass {
     fn from(value: u16) -> Self {
         match value {

--- a/lib-dns-types/src/zones/deserialise.rs
+++ b/lib-dns-types/src/zones/deserialise.rs
@@ -381,28 +381,28 @@ fn try_parse_rtype_with_data(
         return None;
     }
 
-    match tokens[0].0.as_str() {
-        "A" if tokens.len() == 2 => match Ipv4Addr::from_str(&tokens[1].0) {
+    match RecordType::from_str(tokens[0].0.as_str()) {
+        Ok(RecordType::A) if tokens.len() == 2 => match Ipv4Addr::from_str(&tokens[1].0) {
             Ok(address) => Some(RecordTypeWithData::A { address }),
             _ => None,
         },
-        "NS" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::NS) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(nsdname) => Some(RecordTypeWithData::NS { nsdname }),
             _ => None,
         },
-        "MD" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::MD) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(madname) => Some(RecordTypeWithData::MD { madname }),
             _ => None,
         },
-        "MF" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::MF) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(madname) => Some(RecordTypeWithData::MF { madname }),
             _ => None,
         },
-        "CNAME" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::CNAME) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(cname) => Some(RecordTypeWithData::CNAME { cname }),
             _ => None,
         },
-        "SOA" if tokens.len() == 8 => match (
+        Ok(RecordType::SOA) if tokens.len() == 8 => match (
             parse_domain(origin, &tokens[1].0),
             parse_domain(origin, &tokens[2].0),
             u32::from_str(&tokens[3].0),
@@ -424,39 +424,39 @@ fn try_parse_rtype_with_data(
             }
             _ => None,
         },
-        "MB" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::MB) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(madname) => Some(RecordTypeWithData::MB { madname }),
             _ => None,
         },
-        "MG" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::MG) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(mdmname) => Some(RecordTypeWithData::MG { mdmname }),
             _ => None,
         },
-        "MR" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::MR) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(newname) => Some(RecordTypeWithData::MR { newname }),
             _ => None,
         },
-        "NULL" if tokens.len() == 2 => Some(RecordTypeWithData::NULL {
+        Ok(RecordType::NULL) if tokens.len() == 2 => Some(RecordTypeWithData::NULL {
             octets: tokens[1].1.clone(),
         }),
-        "WKS" if tokens.len() == 2 => Some(RecordTypeWithData::WKS {
+        Ok(RecordType::WKS) if tokens.len() == 2 => Some(RecordTypeWithData::WKS {
             octets: tokens[1].1.clone(),
         }),
-        "PTR" if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
+        Ok(RecordType::PTR) if tokens.len() == 2 => match parse_domain(origin, &tokens[1].0) {
             Ok(ptrdname) => Some(RecordTypeWithData::PTR { ptrdname }),
             _ => None,
         },
-        "HINFO" if tokens.len() == 2 => Some(RecordTypeWithData::HINFO {
+        Ok(RecordType::HINFO) if tokens.len() == 2 => Some(RecordTypeWithData::HINFO {
             octets: tokens[1].1.clone(),
         }),
-        "MINFO" if tokens.len() == 3 => match (
+        Ok(RecordType::MINFO) if tokens.len() == 3 => match (
             parse_domain(origin, &tokens[1].0),
             parse_domain(origin, &tokens[2].0),
         ) {
             (Ok(rmailbx), Ok(emailbx)) => Some(RecordTypeWithData::MINFO { rmailbx, emailbx }),
             _ => None,
         },
-        "MX" if tokens.len() == 3 => {
+        Ok(RecordType::MX) if tokens.len() == 3 => {
             match (
                 u16::from_str(&tokens[1].0),
                 parse_domain(origin, &tokens[2].0),
@@ -468,14 +468,14 @@ fn try_parse_rtype_with_data(
                 _ => None,
             }
         }
-        "TXT" if tokens.len() == 2 => Some(RecordTypeWithData::TXT {
+        Ok(RecordType::TXT) if tokens.len() == 2 => Some(RecordTypeWithData::TXT {
             octets: tokens[1].1.clone(),
         }),
-        "AAAA" if tokens.len() == 2 => match Ipv6Addr::from_str(&tokens[1].0) {
+        Ok(RecordType::AAAA) if tokens.len() == 2 => match Ipv6Addr::from_str(&tokens[1].0) {
             Ok(address) => Some(RecordTypeWithData::AAAA { address }),
             _ => None,
         },
-        "SRV" if tokens.len() == 5 => match (
+        Ok(RecordType::SRV) if tokens.len() == 5 => match (
             u16::from_str(&tokens[1].0),
             u16::from_str(&tokens[2].0),
             u16::from_str(&tokens[3].0),


### PR DESCRIPTION
There is no visible behavioural change here, since records of unknown type or non-IN class are still rejected.