### PR TITLE
Implement logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +606,7 @@ dependencies = [
  "priority-queue",
  "rand",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -929,6 +939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1323,6 +1342,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -1342,6 +1364,8 @@ dependencies = [
  "lazy_static",
  "prometheus",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1442,6 +1466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1564,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1644,7 +1686,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1654,6 +1708,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+dependencies = [
+ "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1700,6 +1784,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ have IPv6 at home, so this code doesn't support it yet.
 Usage
 -----
 
-**While `resolved` does work, you probably don't want to use it yet.
-Much of the code is untested and prototype quality.  You *definitely*
-don't want to expose this to the internet.  There will be bugs and
-maybe even exploits.**
+### The DNS Server
+
+**I use `resolved` for my home network with no problems, but it may
+not work for you.  You also probably don't want to expose this to the
+internet!**
+
+Compile it in release mode and run it like so:
 
 ```
 cargo build --release
@@ -29,15 +32,35 @@ sudo ./target/release/resolved -Z config/zones
 Since `resolved` binds to port 53 (both UDP and TCP), it needs to be
 run as root or to have the `CAP_NET_BIND_SERVICE` capability.
 
+See the `--help` text for options.
+
+**Signals:**
+
+- `SIGUSR1` - reload the configuration
+
+**Monitoring:**
+
+- Prometheus metrics are exposed at `http://127.0.0.1:9420/metrics`
+- Log level can be controlled with the `RUST_LOG` environment variable:
+  - `RUST_LOG=trace` - verbose messages useful for development, like
+    "entered function X"
+  - `RUST_LOG=debug` - warns about strange but recoverable situations,
+    like "socket read error"
+  - `RUST_LOG=info` - gives top-level information, like "new
+    connection" or "reloading configuration"
+  - `RUST_LOG=warn` - warns about recoverable internal errors and
+    invalid configuration, like "could not serialise message" or
+    "invalid record in cache"
+  - `RUST_LOG=error` - warns about fatal errors and then terminates
+    the process, like "could not bind socket"
+
+### Other Tools
+
 There are also four utility programs---`htoh`, `htoz`, `ztoh`, and
 `ztoz`---to convert between hosts files and zone files.  They accept
 any syntactically valid file as input, and output it in a consistent
 format regardless of how the input is structured.  So `htoh` and
 `ztoz` can be used to normalise existing files.
-
-**Signals:**
-
-- `SIGUSR1` - reload the configuration
 
 
 Development

--- a/bin-resolved/Cargo.toml
+++ b/bin-resolved/Cargo.toml
@@ -14,3 +14,5 @@ dns-resolver = { path = "../lib-dns-resolver" }
 lazy_static = "1"
 prometheus = { version = "0.13.0", features = ["process"] }
 tokio = { version = "1", features = ["fs", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tracing = "0.1.32"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/bin-resolved/src/metrics.rs
+++ b/bin-resolved/src/metrics.rs
@@ -121,21 +121,12 @@ lazy_static! {
 #[get("/metrics")]
 async fn get_metrics() -> impl Responder {
     match TextEncoder::new().encode_to_string(&prometheus::gather()) {
-        Ok(metrics_str) => {
-            println!("[WEB] metrics request ok");
-            HttpResponse::Ok()
-                .content_type(ContentType::plaintext())
-                .body(metrics_str)
-        }
-        Err(err) => {
-            println!(
-                "[WEB] [INTERNAL ERROR] could not serialise metrics: \"{:?}\"",
-                err
-            );
-            HttpResponse::InternalServerError()
-                .content_type(ContentType::plaintext())
-                .body(err.to_string())
-        }
+        Ok(metrics_str) => HttpResponse::Ok()
+            .content_type(ContentType::plaintext())
+            .body(metrics_str),
+        Err(err) => HttpResponse::InternalServerError()
+            .content_type(ContentType::plaintext())
+            .body(err.to_string()),
     }
 }
 

--- a/lib-dns-resolver/Cargo.toml
+++ b/lib-dns-resolver/Cargo.toml
@@ -12,6 +12,7 @@ dns-types = { path = "../lib-dns-types" }
 priority-queue = "1"
 rand = "0.8.5"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
+tracing = "0.1.32"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/lib-dns-resolver/src/cache.rs
+++ b/lib-dns-resolver/src/cache.rs
@@ -163,15 +163,7 @@ impl Cache {
     ///
     /// If the number of entries exceeds this, expired and
     /// least-recently-used items will be pruned.
-    ///
-    /// Panics:
-    ///
-    /// - If called with a desired_size of 0.
     pub fn with_desired_size(desired_size: usize) -> Self {
-        if desired_size == 0 {
-            panic!("cannot create a zero-size cache");
-        }
-
         Self {
             // `desired_size / 2` is a compromise: most domains will
             // have more than one record, so `desired_size` would be

--- a/lib-dns-resolver/src/metrics.rs
+++ b/lib-dns-resolver/src/metrics.rs
@@ -88,12 +88,12 @@ impl Metrics {
         }
     }
 
-    pub fn cache_hit_or_miss(&mut self, cached_rrs: &[ResourceRecord]) {
-        if cached_rrs.is_empty() {
-            self.cache_misses += 1;
-        } else {
-            self.cache_hits += 1;
-        }
+    pub fn cache_hit(&mut self) {
+        self.cache_hits += 1;
+    }
+
+    pub fn cache_miss(&mut self) {
+        self.cache_misses += 1;
     }
 
     pub fn nameserver_hit(&mut self) {

--- a/lib-dns-resolver/src/nonrecursive.rs
+++ b/lib-dns-resolver/src/nonrecursive.rs
@@ -1,9 +1,14 @@
+use tracing;
+
 use dns_types::protocol::types::*;
 use dns_types::zones::types::*;
 
 use crate::cache::SharedCache;
 use crate::metrics::Metrics;
 use crate::util::types::*;
+
+/// Query type for CNAMEs - used for cache lookups.
+const CNAME_QTYPE: QueryType = QueryType::Record(RecordType::CNAME);
 
 /// Non-recursive DNS resolution.
 ///
@@ -34,13 +39,18 @@ pub fn resolve_nonrecursive(
     cache: &SharedCache,
     question: &Question,
 ) -> Option<Result<NameserverResponse, AuthoritativeNameError>> {
+    let _span = tracing::error_span!("resolve_nonrecursive", %question).entered();
+
     if recursion_limit == 0 {
+        tracing::debug!("hit recursion limit");
         return None;
     }
 
     let mut rrs_from_zone = Vec::new();
 
     if let Some(zone) = zones.get(&question.name) {
+        let _zone_span = tracing::error_span!("zone", apex = %zone.get_apex().to_dotted_string(), is_authoritative = %zone.is_authoritative()).entered();
+
         // `zone.resolve` implements the non-recursive part of step 3
         // of the standard resolver algorithm: matching down through
         // the zone and returning what sort of end state is reached.
@@ -62,18 +72,7 @@ pub fn resolve_nonrecursive(
             //    prioritising merge to combine the RR sets,
             //    preserving the override behaviour.
             Some(ZoneResult::Answer { rrs }) => {
-                println!(
-                    "[DEBUG] zone {:?} {} ANSWER for {:?} {:?} {:?}",
-                    zone.get_apex().to_dotted_string(),
-                    if zone.is_authoritative() {
-                        "AUTHORITATIVE"
-                    } else {
-                        "NON-AUTHORITATIVE"
-                    },
-                    question.name.to_dotted_string(),
-                    question.qclass,
-                    question.qtype
-                );
+                tracing::trace!("got answer");
                 metrics.zoneresult_answer(&rrs, zone, question);
 
                 if let Some(soa_rr) = zone.soa_rr() {
@@ -107,18 +106,7 @@ pub fn resolve_nonrecursive(
             // authoritative if and only if this starting zone is
             // authoritative.
             Some(ZoneResult::CNAME { cname, rr }) => {
-                println!(
-                    "[DEBUG] zone {:?} {} CNAME for {:?} {:?} {:?}",
-                    zone.get_apex().to_dotted_string(),
-                    if zone.is_authoritative() {
-                        "AUTHORITATIVE"
-                    } else {
-                        "NON-AUTHORITATIVE"
-                    },
-                    question.name.to_dotted_string(),
-                    question.qclass,
-                    question.qtype
-                );
+                tracing::trace!("got cname");
                 metrics.zoneresult_cname(zone);
 
                 let mut rrs = vec![rr];
@@ -176,23 +164,12 @@ pub fn resolve_nonrecursive(
             //
             // - otherwise ignore and proceed to cache.
             Some(ZoneResult::Delegation { ns_rrs }) => {
-                println!(
-                    "[DEBUG] zone {:?} {} DELEGATION for {:?} {:?} {:?}",
-                    zone.get_apex().to_dotted_string(),
-                    if zone.is_authoritative() {
-                        "AUTHORITATIVE"
-                    } else {
-                        "NON-AUTHORITATIVE"
-                    },
-                    question.name.to_dotted_string(),
-                    question.qclass,
-                    question.qtype
-                );
+                tracing::trace!("got delegation");
                 metrics.zoneresult_delegation(zone);
 
                 if zone.is_authoritative() {
                     if ns_rrs.is_empty() {
-                        println!("[ERROR] got an empty RRset from delegation");
+                        tracing::warn!("got empty RRset from delegation");
                         return None;
                     }
 
@@ -202,7 +179,7 @@ pub fn resolve_nonrecursive(
                         if let RecordTypeWithData::NS { nsdname } = &rr.rtype_with_data {
                             hostnames.push(HostOrIP::Host(nsdname.clone()));
                         } else {
-                            println!("[ERROR] got a non-NS RR in a delegation");
+                            tracing::warn!(rtype = %rr.rtype_with_data.rtype(), "got non-NS RR in a delegation");
                         }
                     }
 
@@ -219,18 +196,7 @@ pub fn resolve_nonrecursive(
             //
             // - otherwise ignore and proceed to cache.
             Some(ZoneResult::NameError) => {
-                println!(
-                    "[DEBUG] zone {:?} {} NAME ERROR for {:?} {:?} {:?}",
-                    zone.get_apex().to_dotted_string(),
-                    if zone.is_authoritative() {
-                        "AUTHORITATIVE"
-                    } else {
-                        "NON-AUTHORITATIVE"
-                    },
-                    question.name.to_dotted_string(),
-                    question.qclass,
-                    question.qtype
-                );
+                tracing::trace!("got name error");
                 metrics.zoneresult_nameerror(zone);
 
                 if let Some(soa_rr) = zone.soa_rr() {
@@ -239,12 +205,7 @@ pub fn resolve_nonrecursive(
             }
             // This shouldn't happen
             None => {
-                println!(
-                    "[ERROR] zone {:?} domain {:?} mis-match!",
-                    zone.get_apex().to_dotted_string(),
-                    question.name.to_dotted_string()
-                );
-
+                tracing::warn!("zone apex / domain mismatch");
                 return None;
             }
         }
@@ -269,34 +230,24 @@ pub fn resolve_nonrecursive(
     // and combine with the RRs we already have.
 
     let mut rrs_from_cache = cache.get(&question.name, &question.qtype);
-    println!(
-        "[DEBUG] cache {} for {:?} {:?} {:?}",
-        if rrs_from_cache.is_empty() {
-            "MISS"
-        } else {
-            "HIT"
-        },
-        question.name.to_dotted_string(),
-        question.qclass,
-        question.qtype
-    );
-    metrics.cache_hit_or_miss(&rrs_from_cache);
+    if rrs_from_cache.is_empty() {
+        tracing::trace!(qtype = %question.qtype, "cache MISS");
+        metrics.cache_miss();
+    } else {
+        tracing::trace!(qtype = %question.qtype, "cache HIT");
+        metrics.cache_hit();
+    }
 
     let mut final_cname = None;
-    if rrs_from_cache.is_empty() && question.qtype != QueryType::Record(RecordType::CNAME) {
-        let cache_cname_rrs = cache.get(&question.name, &QueryType::Record(RecordType::CNAME));
-        println!(
-            "[DEBUG] cache CNAME {} for {:?} {:?} {:?}",
-            if cache_cname_rrs.is_empty() {
-                "MISS"
-            } else {
-                "HIT"
-            },
-            question.name.to_dotted_string(),
-            question.qclass,
-            question.qtype
-        );
-        metrics.cache_hit_or_miss(&cache_cname_rrs);
+    if rrs_from_cache.is_empty() && question.qtype != CNAME_QTYPE {
+        let cache_cname_rrs = cache.get(&question.name, &CNAME_QTYPE);
+        if cache_cname_rrs.is_empty() {
+            tracing::trace!(qtype = %CNAME_QTYPE, "cache MISS");
+            metrics.cache_miss();
+        } else {
+            tracing::trace!(qtype = %CNAME_QTYPE, "cache HIT");
+            metrics.cache_hit();
+        }
 
         if !cache_cname_rrs.is_empty() {
             let cname_rr = cache_cname_rrs[0].clone();
@@ -327,7 +278,7 @@ pub fn resolve_nonrecursive(
                     }
                 }
             } else {
-                println!("[ERROR] expected CNAME RR (in cache)");
+                tracing::warn!(rtype = %cname_rr.rtype_with_data.rtype(), "got non-CNAME RR from cache");
                 return None;
             };
         }

--- a/lib-dns-resolver/src/nonrecursive.rs
+++ b/lib-dns-resolver/src/nonrecursive.rs
@@ -106,7 +106,7 @@ pub fn resolve_nonrecursive(
             // - if resolving it fails: return the response, which is
             // authoritative if and only if this starting zone is
             // authoritative.
-            Some(ZoneResult::CNAME { cname_rr }) => {
+            Some(ZoneResult::CNAME { cname, rr }) => {
                 println!(
                     "[DEBUG] zone {:?} {} CNAME for {:?} {:?} {:?}",
                     zone.get_apex().to_dotted_string(),
@@ -121,14 +121,7 @@ pub fn resolve_nonrecursive(
                 );
                 metrics.zoneresult_cname(zone);
 
-                let cname = if let RecordTypeWithData::CNAME { cname } = &cname_rr.rtype_with_data {
-                    cname
-                } else {
-                    println!("[ERROR] expected CNAME RR (in zone)");
-                    return None;
-                };
-
-                let mut rrs = vec![cname_rr.clone()];
+                let mut rrs = vec![rr];
                 return Some(Ok(
                     match resolve_nonrecursive(
                         recursion_limit - 1,
@@ -170,7 +163,7 @@ pub fn resolve_nonrecursive(
                         }
                         _ => NameserverResponse::CNAME {
                             rrs,
-                            cname: cname.clone(),
+                            cname,
                             is_authoritative: zone.is_authoritative(),
                         },
                     },

--- a/lib-dns-types/src/protocol/types.rs
+++ b/lib-dns-types/src/protocol/types.rs
@@ -272,6 +272,18 @@ impl Question {
     }
 }
 
+impl fmt::Display for Question {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {}",
+            self.name.to_dotted_string(),
+            self.qclass,
+            self.qtype
+        )
+    }
+}
+
 /// The answer, authority, and additional sections are all the same
 /// format: a variable number of resource records.  This is the
 /// structure for a single resource record.


### PR DESCRIPTION
The following levels are used in `dns-resolver`:

- `TRACE`: logs on most function calls and match branches, this more
or less replicates the previous logging

- `DEBUG`: logs on suspicious but minor errors which indicate
something is probably wrong externally

- `WARN`: logs on non-fatal internal errors, but these probably
indicate bugs.

- `ERROR`: logs on fatal errors and then immediately exits.

The only fatal errors in `dns-resolver` are in the network utility
functions.

The following levels are used in `resolved`:

- `INFO`: logs top-level events, like new connections or answered
questions

- `WARN`: logs on non-fatal internal and configuration errors.

- `ERROR`: logs on fatal errors and then immediately exits.

Log level can be configured with the `RUST_LOG` env var.  See the
README for an example.

---

This PR also removes some possible error states from `lib-dns-resolver`.

Closes #19