### PR TITLE
Add env var to set log format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,12 +1742,15 @@ dependencies = [
  "lazy_static",
  "matchers",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ See the `--help` text for options.
     "invalid record in cache"
   - `RUST_LOG=error` - warns about fatal errors and then terminates
     the process, like "could not bind socket"
+- Log format can be controlled with the `RUST_LOG_FORMAT` environment
+  variable, which is a sequence of comma-separated values:
+  - One of `full` (default), `compact`, `pretty`, or `json` - see [the
+    tracing_subscriber crate][]
+  - One of `ansi` (default), `no-ansi`
+  - One of `time` (default), `no-time`
+
+[the tracing_subscriber crate]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/index.html#formatters
 
 ### Other Tools
 

--- a/bin-resolved/Cargo.toml
+++ b/bin-resolved/Cargo.toml
@@ -15,4 +15,4 @@ lazy_static = "1"
 prometheus = { version = "0.13.0", features = ["process"] }
 tokio = { version = "1", features = ["fs", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = "0.1.32"
-tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.9", features = ["env-filter", "json"] }


### PR DESCRIPTION
`RUST_LOG_FORMAT=json,no-time` will be useful for systemd, as it
already includes timestamps in the journal, and the lack of colours
make a more structured format handy.