### PR TITLE
Fix missing NameserverResponse to ResolvedRecord cases

### DIFF
--- a/lib-dns-resolver/src/nonrecursive.rs
+++ b/lib-dns-resolver/src/nonrecursive.rs
@@ -167,7 +167,7 @@ pub fn resolve_nonrecursive(
                 tracing::trace!("got delegation");
                 metrics.zoneresult_delegation(zone);
 
-                if zone.is_authoritative() {
+                if let Some(soa_rr) = zone.soa_rr() {
                     if ns_rrs.is_empty() {
                         tracing::warn!("got empty RRset from delegation");
                         return None;
@@ -186,6 +186,8 @@ pub fn resolve_nonrecursive(
                     return Some(Ok(NameserverResponse::Delegation {
                         delegation: Nameservers { name, hostnames },
                         rrs: ns_rrs,
+                        is_authoritative: true,
+                        authority_rrs: vec![soa_rr],
                     }));
                 }
             }
@@ -599,6 +601,8 @@ mod tests {
                     "delegated.authoritative.example.com.",
                     "ns.delegated.authoritative.example.com."
                 )],
+                authority_rrs: vec![zones_soa_rr()],
+                is_authoritative: true,
                 delegation: Nameservers {
                     name: domain("delegated.authoritative.example.com."),
                     hostnames: vec![HostOrIP::Host(domain(

--- a/lib-dns-resolver/src/util/types.rs
+++ b/lib-dns-resolver/src/util/types.rs
@@ -72,6 +72,8 @@ pub enum NameserverResponse {
     Delegation {
         rrs: Vec<ResourceRecord>,
         delegation: Nameservers,
+        is_authoritative: bool,
+        authority_rrs: Vec<ResourceRecord>,
     },
 }
 
@@ -88,8 +90,32 @@ impl From<NameserverResponse> for ResolvedRecord {
                 rrs,
                 ..
             } => ResolvedRecord::NonAuthoritative { rrs },
-            NameserverResponse::CNAME { .. } => todo!(),
-            NameserverResponse::Delegation { .. } => todo!(),
+            NameserverResponse::CNAME {
+                rrs,
+                is_authoritative,
+                ..
+            } => {
+                if is_authoritative {
+                    ResolvedRecord::Authoritative {
+                        rrs,
+                        authority_rrs: Vec::new(),
+                    }
+                } else {
+                    ResolvedRecord::NonAuthoritative { rrs }
+                }
+            }
+            NameserverResponse::Delegation {
+                rrs,
+                is_authoritative,
+                authority_rrs,
+                ..
+            } => {
+                if is_authoritative {
+                    ResolvedRecord::Authoritative { rrs, authority_rrs }
+                } else {
+                    ResolvedRecord::NonAuthoritative { rrs }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
These haven't caused a problem yet because nothing makes non-recursive
queries.  Also implement authority for non-recursive delegation.