### PR TITLE
Make fuzz tests more uniform

### DIFF
--- a/fuzz/fuzz_targets/hosts_deserialise_round_trip.rs
+++ b/fuzz/fuzz_targets/hosts_deserialise_round_trip.rs
@@ -4,18 +4,9 @@ use libfuzzer_sys::fuzz_target;
 use dns_types::hosts::types::Hosts;
 
 fuzz_target!(|data: &str| {
-    if let Ok(deserialised) = Hosts::deserialise(data) {
-        let serialised = deserialised.clone().serialise();
-        if let Ok(re_deserialised) = Hosts::deserialise(&serialised) {
-            if deserialised != re_deserialised {
-                panic!(
-                    "\n   deserialised: {:?}\n\nre-deserialised: {:?}\n\n{:?}",
-                    deserialised, re_deserialised, serialised
-                );
-            }
-            assert_eq!(deserialised, re_deserialised);
-        } else {
-            panic!("expected successful re-deserialisation");
-        }
+    if let Ok(hosts) = Hosts::deserialise(data) {
+        let serialised = hosts.clone().serialise();
+        let deserialised = Hosts::deserialise(&serialised);
+        assert_eq!(Ok(hosts), deserialised);
     }
 });

--- a/fuzz/fuzz_targets/hosts_serialise_round_trip.rs
+++ b/fuzz/fuzz_targets/hosts_serialise_round_trip.rs
@@ -5,12 +5,6 @@ use dns_types::hosts::types::Hosts;
 
 fuzz_target!(|hosts: Hosts| {
     let serialised = hosts.serialise();
-    if let Ok(deserialised) = Hosts::deserialise(&serialised) {
-        assert_eq!(hosts, deserialised);
-    } else {
-        panic!(
-            "expected successful deserialisation\n\n{:?}\n\n{:?}",
-            hosts, serialised
-        );
-    }
+    let deserialised = Hosts::deserialise(&serialised);
+    assert_eq!(Ok(hosts), deserialised);
 });

--- a/fuzz/fuzz_targets/wire_deserialise_round_trip.rs
+++ b/fuzz/fuzz_targets/wire_deserialise_round_trip.rs
@@ -4,9 +4,9 @@ use libfuzzer_sys::fuzz_target;
 use dns_types::protocol::types::Message;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(deserialised) = Message::from_octets(data) {
-        let serialised = deserialised.clone().to_octets().unwrap();
-        let re_deserialised = Message::from_octets(&serialised);
-        assert_eq!(Ok(deserialised), re_deserialised);
+    if let Ok(message) = Message::from_octets(data) {
+        let serialised = message.clone().to_octets().unwrap();
+        let deserialised = Message::from_octets(&serialised);
+        assert_eq!(Ok(message), deserialised);
     }
 });

--- a/fuzz/fuzz_targets/zone_deserialise_round_trip.rs
+++ b/fuzz/fuzz_targets/zone_deserialise_round_trip.rs
@@ -4,12 +4,9 @@ use libfuzzer_sys::fuzz_target;
 use dns_types::zones::types::Zone;
 
 fuzz_target!(|data: &str| {
-    if let Ok(deserialised) = Zone::deserialise(data) {
-        let serialised = deserialised.clone().serialise();
-        if let Ok(re_deserialised) = Zone::deserialise(&serialised) {
-            assert_eq!(deserialised, re_deserialised);
-        } else {
-            panic!("expected successful re-deserialisation");
-        }
+    if let Ok(zone) = Zone::deserialise(data) {
+        let serialised = zone.clone().serialise();
+        let deserialised = Zone::deserialise(&serialised);
+        assert_eq!(Ok(zone), deserialised);
     }
 });

--- a/fuzz/fuzz_targets/zone_serialise_round_trip.rs
+++ b/fuzz/fuzz_targets/zone_serialise_round_trip.rs
@@ -5,9 +5,6 @@ use dns_types::zones::types::Zone;
 
 fuzz_target!(|zone: Zone| {
     let serialised = zone.serialise();
-    if let Ok(deserialised) = Zone::deserialise(&serialised) {
-        assert_eq!(zone, deserialised);
-    } else {
-        panic!("expected successful deserialisation");
-    }
+    let deserialised = Zone::deserialise(&serialised);
+    assert_eq!(Ok(zone), deserialised);
 });


### PR DESCRIPTION
There's no need for separate checks and panics, `assert_eq!` is
enough.