### PR TITLE
Run PR fuzz tests in separate action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,18 @@ jobs:
       - name: Check benchmarks compile
         run: cargo bench --no-run
 
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 


### PR DESCRIPTION
This will run them concurrently with the other tests, reducing the overall time to merge a PR.