### PR TITLE
Don't dead-end on candidate name resolution failure

### DIFF
--- a/lib-dns-resolver/src/lib.rs
+++ b/lib-dns-resolver/src/lib.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::pedantic)]
+// Sometimes a redundant else is clearer
+#![allow(clippy::redundant_else)]
 // Don't care enough to fix
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::must_use_candidate)]


### PR DESCRIPTION
If a candidate's hostname can't be resolved to an IP address, just move on and try the next one: the whole reason for giving multiple nameservers is fault tolerance.

This doesn't remove the dead end on miss, as that needs to be a bit smarter: it would be no good just retrying if the name doesn't exist, as we'd hit a lot of nameservers unnecessarily!  We should only retry on a miss if it was due to a network error which prevented a response from arriving.