### PR TITLE
Remove unnecessary `HostOrIP` enum

### DIFF
--- a/lib-dns-resolver/src/local.rs
+++ b/lib-dns-resolver/src/local.rs
@@ -210,7 +210,7 @@ pub fn resolve_local(
                     let mut hostnames = Vec::with_capacity(ns_rrs.len());
                     for rr in &ns_rrs {
                         if let RecordTypeWithData::NS { nsdname } = &rr.rtype_with_data {
-                            hostnames.push(HostOrIP::Host(nsdname.clone()));
+                            hostnames.push(nsdname.clone());
                         } else {
                             tracing::warn!(rtype = %rr.rtype_with_data.rtype(), "got non-NS RR in a delegation");
                         }
@@ -708,9 +708,7 @@ mod tests {
                 is_authoritative: true,
                 delegation: Nameservers {
                     name: domain("delegated.authoritative.example.com."),
-                    hostnames: vec![HostOrIP::Host(domain(
-                        "ns.delegated.authoritative.example.com."
-                    ))],
+                    hostnames: vec![domain("ns.delegated.authoritative.example.com.")],
                 }
             }),
             resolve_local(

--- a/lib-dns-resolver/src/util/types.rs
+++ b/lib-dns-resolver/src/util/types.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::net::Ipv4Addr;
 
 use dns_types::protocol::types::*;
 
@@ -79,7 +78,7 @@ pub struct Nameservers {
     /// Guaranteed to be non-empty.
     ///
     /// TODO: find a non-empty-vec type
-    pub hostnames: Vec<HostOrIP>,
+    pub hostnames: Vec<DomainName>,
     pub name: DomainName,
 }
 
@@ -87,13 +86,6 @@ impl Nameservers {
     pub fn match_count(&self) -> usize {
         self.name.labels.len()
     }
-}
-
-/// A hostname or an IP
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum HostOrIP {
-    Host(DomainName),
-    IP(Ipv4Addr),
 }
 
 /// Merge two sets of RRs, where records from the second set are
@@ -142,6 +134,8 @@ pub fn prioritising_merge(priority: &mut Vec<ResourceRecord>, new: Vec<ResourceR
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use dns_types::protocol::types::test_util::*;
 
     use super::*;


### PR DESCRIPTION
Only one variant of this is ever used, so the inner type can just be used directly.