### PR TITLE
Prevent cycles in questions

### DIFF
--- a/lib-dns-resolver/src/util/types.rs
+++ b/lib-dns-resolver/src/util/types.rs
@@ -39,6 +39,8 @@ pub enum ResolutionError {
     Timeout,
     /// Hit the recursion limit while following CNAMEs.
     RecursionLimit,
+    /// Tried to resolve a question while resolving the same question.
+    DuplicateQuestion { question: Question },
     /// Was unable to resolve a necessary record.
     DeadEnd { question: Question },
     /// Configuration error: a local zone delegates without defining NS records.
@@ -59,6 +61,7 @@ impl std::fmt::Display for ResolutionError {
         match self {
             ResolutionError::Timeout => write!(f, "timed out"),
             ResolutionError::RecursionLimit => write!(f, "CNAME chain too long"),
+            ResolutionError::DuplicateQuestion{question} => write!(f, "loop when answering '{} {} {}'", question.name, question.qclass, question.qtype),
             ResolutionError::DeadEnd{question} => write!(f, "unable to answer '{} {} {}'", question.name, question.qclass, question.qtype),
             ResolutionError::LocalDelegationMissingNS{apex,domain} => write!(f, "configuration error: got delegation for domain '{domain}' from zone '{apex}', but there are no NS records"),
             ResolutionError::CacheTypeMismatch{query,result} => write!(f, "internal error (bug): tried to fetch '{query}' from cache but got '{result}' instead"),


### PR DESCRIPTION
If a domain's nameservers are incorrectly configured such that `A` records can't be found (eg, missing glue records), the recursive resolver will bounce back and forth between the nameservers until it hits the recursion limit.  If the domain has several nameservers, this may result in a lot of waiting while many different redundant orderings get tried.

However, we can bail out much sooner if we detect a cycle: if finding the `A` record for `ns1.example.com` requires (even if indirectly) finding the `A` record for `ns1.example.com`, then we're stuck.  There's no point going around this cycle 25 times until the recursion depth is hit.  We can abort then.

So this commit replaces the `recursion_limit` with a `question_stack`, and resolvers now check if they've been caught in a loop in addition to checking the recursion depth.