### PR TITLE
Replace `fake` dependency with `rand`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "criterion",
- "fake",
+ "rand",
 ]
 
 [[package]]
@@ -675,16 +675,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "fake"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a44c765350db469b774425ff1c833890b16ceb9612fb5d7c4bbdf4a1b55f876"
-dependencies = [
- "rand",
- "unidecode",
 ]
 
 [[package]]
@@ -1847,12 +1837,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unidecode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
 
 [[package]]
 name = "url"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -42,15 +42,6 @@ name = "dns-types"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "fake",
-]
-
-[[package]]
-name = "fake"
-version = "2.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a8531dd3a64fd1cfbe92fad4160bc2060489c6195fe847e045e5788f710bae"
-dependencies = [
  "rand",
 ]
 

--- a/lib-dns-types/Cargo.toml
+++ b/lib-dns-types/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2021"
 
 [dependencies]
 arbitrary = { version = "1", features = ["derive"], optional = true }
-fake = { version = "2", optional = true }
+rand = { version = "0.8.5", optional = true }
 
 [dev-dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 criterion = "0.4.0"
-fake = "2"
+rand = "0.8.5"
 
 [features]
-test-util = ["arbitrary", "fake"]
+test-util = ["arbitrary", "rand"]
 
 [[bench]]
 name = "serialise_deserialise"

--- a/lib-dns-types/src/hosts/types.rs
+++ b/lib-dns-types/src/hosts/types.rs
@@ -184,13 +184,14 @@ pub mod test_util {
     use super::*;
 
     use arbitrary::{Arbitrary, Unstructured};
-    use fake::{Fake, Faker};
+    use rand::Rng;
 
     pub fn arbitrary_hosts() -> Hosts {
+        let mut rng = rand::thread_rng();
         for size in [128, 256, 512, 1024, 2048, 4096] {
             let mut buf = Vec::new();
             for _ in 0..size {
-                buf.push(Faker.fake());
+                buf.push(rng.gen());
             }
 
             if let Ok(rr) = Hosts::arbitrary(&mut Unstructured::new(&buf)) {

--- a/lib-dns-types/src/protocol/types.rs
+++ b/lib-dns-types/src/protocol/types.rs
@@ -1565,7 +1565,7 @@ impl<'a> arbitrary::Arbitrary<'a> for RecordClass {
 
 #[cfg(test)]
 mod tests {
-    use fake::Fake;
+    use rand::Rng;
 
     use super::test_util::*;
     use super::*;
@@ -1674,15 +1674,16 @@ mod tests {
 
     #[test]
     fn domainname_conversions() {
+        let mut rng = rand::thread_rng();
         for _ in 0..100 {
-            let labels_len = (0..5).fake::<usize>();
+            let labels_len = rng.gen_range(0..5);
 
             let mut dotted_string_input = String::new();
             let mut labels_input = Vec::with_capacity(labels_len);
             let mut output = String::new();
 
             for i in 0..labels_len {
-                let label_len = (1..10).fake::<usize>();
+                let label_len = rng.gen_range(1..10);
 
                 if i > 0 {
                     dotted_string_input.push('.');
@@ -1691,7 +1692,7 @@ mod tests {
 
                 let mut octets = Vec::with_capacity(label_len);
                 for _ in 0..label_len {
-                    let mut chr = (32..126).fake::<u8>();
+                    let mut chr = rng.gen_range(32..126);
 
                     if chr == b'.'
                         || chr == b'*'
@@ -1737,13 +1738,14 @@ pub mod test_util {
     use super::*;
 
     use arbitrary::{Arbitrary, Unstructured};
-    use fake::{Fake, Faker};
+    use rand::Rng;
 
     pub fn arbitrary_resourcerecord() -> ResourceRecord {
+        let mut rng = rand::thread_rng();
         for size in [128, 256, 512, 1024, 2048, 4096] {
             let mut buf = Vec::new();
             for _ in 0..size {
-                buf.push(Faker.fake());
+                buf.push(rng.gen());
             }
 
             if let Ok(rr) = ResourceRecord::arbitrary(&mut Unstructured::new(&buf)) {


### PR DESCRIPTION
I'm only using `fake` to generate random numbers, which `rand` can do perfectly well.