### PR TITLE
Fix tracing & proc-macro2 issues in build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,10 +1738,11 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -1750,13 +1751,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.2",
+ "syn 1.0.102",
 ]
 
 [[package]]

--- a/bin-resolved/Cargo.toml
+++ b/bin-resolved/Cargo.toml
@@ -14,5 +14,5 @@ dns-resolver = { path = "../lib-dns-resolver" }
 lazy_static = "1"
 prometheus = { version = "0.13.3", features = ["process"] }
 tokio = { version = "1", features = ["fs", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -96,11 +96,11 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -160,6 +160,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-xid"

--- a/lib-dns-resolver/Cargo.toml
+++ b/lib-dns-resolver/Cargo.toml
@@ -12,7 +12,7 @@ dns-types = { path = "../lib-dns-types" }
 priority-queue = "1"
 rand = "0.8.5"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/lib-dns-resolver/src/cache.rs
+++ b/lib-dns-resolver/src/cache.rs
@@ -39,6 +39,10 @@ impl SharedCache {
     /// The TTL in the returned `ResourceRecord` is relative to the
     /// current time - not when the record was inserted into the
     /// cache.
+    ///
+    /// # Panics
+    ///
+    /// If the mutex has been poisoned.
     pub fn get(&self, name: &DomainName, qtype: QueryType) -> Vec<ResourceRecord> {
         let mut rrs = self.get_without_checking_expiration(name, qtype);
         rrs.retain(|rr| rr.ttl > 0);
@@ -49,6 +53,10 @@ impl SharedCache {
     ///
     /// Consumers MUST check that the TTL of a record is nonzero
     /// before using it!
+    ///
+    /// # Panics
+    ///
+    /// If the mutex has been poisoned.
     pub fn get_without_checking_expiration(
         &self,
         name: &DomainName,
@@ -65,6 +73,10 @@ impl SharedCache {
     /// It is not inserted if its TTL is zero.
     ///
     /// This may make the cache grow beyond the desired size.
+    ///
+    /// # Panics
+    ///
+    /// If the mutex has been poisoned.
     pub fn insert(&self, record: &ResourceRecord) {
         if record.ttl > 0 {
             let mut cache = self.cache.lock().expect(MUTEX_POISON_MESSAGE);
@@ -75,6 +87,10 @@ impl SharedCache {
     /// Insert multiple entries into the cache.
     ///
     /// This just calls `insert` for each element, nothing more clever.
+    ///
+    /// # Panics
+    ///
+    /// If the mutex has been poisoned.
     pub fn insert_all(&self, records: &[ResourceRecord]) {
         for record in records {
             self.insert(record);
@@ -85,6 +101,10 @@ impl SharedCache {
     /// beyond its desired size, prunes entries to get down to size.
     ///
     /// Returns `(has overflowed?, current size, num expired, num pruned)`.
+    ///
+    /// # Panics
+    ///
+    /// If the mutex has been poisoned.
     pub fn prune(&self) -> (bool, usize, usize, usize) {
         self.cache.lock().expect(MUTEX_POISON_MESSAGE).prune()
     }

--- a/lib-dns-resolver/src/util/types.rs
+++ b/lib-dns-resolver/src/util/types.rs
@@ -124,7 +124,7 @@ impl Nameservers {
 pub fn prioritising_merge(priority: &mut Vec<ResourceRecord>, new: Vec<ResourceRecord>) {
     let mut seen = HashSet::new();
 
-    for rr in priority.iter() {
+    for rr in &*priority {
         seen.insert((rr.name.clone(), rr.rtype_with_data.rtype()));
     }
 


### PR DESCRIPTION
- tracing-0.1.38 has been yanked due to unintentionally including a breaking change.
- proc-macro2-1.0.52 no longer builds with the latest nightly