### PR TITLE
Only return `ServFail` if answers & authority are empty

### DIFF
--- a/bin-resolved/src/main.rs
+++ b/bin-resolved/src/main.rs
@@ -147,7 +147,10 @@ async fn resolve_and_build_response(args: ListenArgs, query: Message) -> Message
 
     prune_cache_and_update_metrics(&args.cache);
 
-    if response.answers.is_empty() && response.header.rcode == Rcode::NoError {
+    if response.answers.is_empty()
+        && response.authority.is_empty()
+        && response.header.rcode == Rcode::NoError
+    {
         response.header.rcode = Rcode::ServerFailure;
         response.header.is_authoritative = false;
     }


### PR DESCRIPTION
There are two cases when the answers can be empty:

- `NXDOMAIN` - the server is authoritative for this zone and the domain does not exist.
- `NODATA` - the server is authoritative for this zone, the domain exists, but there's no record of the requested type.  This commit fixes this case.

In both of these cases, the SOA record should be returned in the authority section.  So, change the `ServFail` case to only return an error if there are no authority records, as that could indicate a failure talking to upstream nameservers.

Additionally, `NODATA` should be returned if the server is non-authoritative for this domain and the authoritative server returns `NXDOMAIN` or `NODATA`.  Changes will be required to the recursive and forwarding resolvers (to pass along the relevant SOA record) to support this case