### PR TITLE
Allow forwarding queries via IPv6 and to any port

### DIFF
--- a/bin-dnsq/src/main.rs
+++ b/bin-dnsq/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
 
@@ -52,9 +52,10 @@ struct Args {
     authoritative_only: bool,
 
     /// Act as a forwarding resolver, not a recursive resolver: forward queries
-    /// which can't be answered from local state to this nameserver
+    /// which can't be answered from local state to this nameserver (in
+    /// `ip:port` form)
     #[clap(short, long, value_parser)]
-    forward_address: Option<Ipv4Addr>,
+    forward_address: Option<SocketAddr>,
 
     /// Path to a hosts file, can be specified more than once
     #[clap(short = 'a', long, value_parser)]

--- a/bin-resolved/src/main.rs
+++ b/bin-resolved/src/main.rs
@@ -2,7 +2,7 @@ use bytes::BytesMut;
 use clap::Parser;
 use std::collections::HashSet;
 use std::env;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
@@ -307,7 +307,7 @@ async fn listen_udp_task(args: ListenArgs, socket: UdpSocket) {
 #[derive(Debug, Clone)]
 struct ListenArgs {
     authoritative_only: bool,
-    forward_address: Option<Ipv4Addr>,
+    forward_address: Option<SocketAddr>,
     zones_lock: Arc<RwLock<Zones>>,
     cache: SharedCache,
 }
@@ -453,9 +453,9 @@ struct Args {
 
     /// Act as a forwarding resolver, not a recursive resolver:
     /// forward queries which can't be answered from local state to
-    /// this nameserver and cache the result
+    /// this nameserver (in `ip:port` form) and cache the result
     #[clap(short, long, value_parser, env = "RESOLVED_FORWARD_ADDRESS")]
-    forward_address: Option<Ipv4Addr>,
+    forward_address: Option<SocketAddr>,
 
     /// How many records to hold in the cache
     #[clap(

--- a/lib-dns-resolver/src/forwarding.rs
+++ b/lib-dns-resolver/src/forwarding.rs
@@ -1,5 +1,5 @@
 use async_recursion::async_recursion;
-use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::time::timeout;
 use tracing::Instrument;
@@ -28,7 +28,7 @@ use crate::util::types::*;
 pub async fn resolve_forwarding(
     question_stack: &mut Vec<Question>,
     metrics: &mut Metrics,
-    forward_address: Ipv4Addr,
+    forward_address: SocketAddr,
     zones: &Zones,
     cache: &SharedCache,
     question: &Question,
@@ -58,7 +58,7 @@ pub async fn resolve_forwarding(
 async fn resolve_forwarding_notimeout(
     question_stack: &mut Vec<Question>,
     metrics: &mut Metrics,
-    forward_address: Ipv4Addr,
+    forward_address: SocketAddr,
     zones: &Zones,
     cache: &SharedCache,
     question: &Question,

--- a/lib-dns-resolver/src/lib.rs
+++ b/lib-dns-resolver/src/lib.rs
@@ -18,7 +18,7 @@ pub mod metrics;
 pub mod recursive;
 pub mod util;
 
-use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 use tracing::Instrument;
 
 use dns_types::protocol::types::Question;
@@ -42,7 +42,7 @@ pub const RECURSION_LIMIT: usize = 32;
 /// Resolve a question using the standard DNS algorithms.
 pub async fn resolve(
     is_recursive: bool,
-    forward_address: Option<Ipv4Addr>,
+    forward_address: Option<SocketAddr>,
     zones: &Zones,
     cache: &SharedCache,
     question: &Question,

--- a/lib-dns-resolver/src/recursive.rs
+++ b/lib-dns-resolver/src/recursive.rs
@@ -15,6 +15,8 @@ use crate::metrics::Metrics;
 use crate::util::nameserver::*;
 use crate::util::types::*;
 
+pub const UPSTREAM_DNS_PORT: u16 = 53;
+
 /// Recursive DNS resolution.
 ///
 /// This corresponds to the standard resolver algorithm.  If
@@ -121,12 +123,13 @@ async fn resolve_recursive_notimeout(
             )
             .await
             {
-                if let Some(nameserver_response) = query_nameserver(ip, question, false)
-                    .instrument(
-                        tracing::error_span!("query_nameserver", address = %ip, %match_count),
-                    )
-                    .await
-                    .and_then(|res| validate_nameserver_response(question, &res, match_count))
+                if let Some(nameserver_response) =
+                    query_nameserver((ip, UPSTREAM_DNS_PORT).into(), question, false)
+                        .instrument(
+                            tracing::error_span!("query_nameserver", address = %ip, %match_count),
+                        )
+                        .await
+                        .and_then(|res| validate_nameserver_response(question, &res, match_count))
                 {
                     if resolve_candidates_locally {
                         tracing::trace!(?candidate, "resolved fast candidate");


### PR DESCRIPTION
This changes the `--forward-address` arg of resolved and dnsq to take an arbitrary socket address (a string in the form `ip:port`) rather than assuming it's an IPv4 address on port 53.  This does mean the port is now required, but I think that's a small price to pay for the extra flexibility.