### PR TITLE
Allow listening on IPv6 and any port

### DIFF
--- a/bin-resolved/src/metrics.rs
+++ b/bin-resolved/src/metrics.rs
@@ -4,7 +4,7 @@ use prometheus::{
     opts, register_histogram_vec, register_int_counter, register_int_counter_vec,
     register_int_gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge, TextEncoder,
 };
-use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 
 pub const RESPONSE_TIME_BUCKETS: &[f64] = &[
     0.0001, // 0.1 ms
@@ -141,9 +141,9 @@ async fn get_metrics() -> impl Responder {
     }
 }
 
-pub async fn serve_prometheus_endpoint_task(address: Ipv4Addr, port: u16) -> std::io::Result<()> {
+pub async fn serve_prometheus_endpoint_task(address: SocketAddr) -> std::io::Result<()> {
     HttpServer::new(|| App::new().service(get_metrics))
-        .bind((address, port))?
+        .bind(address)?
         .run()
         .await
 }


### PR DESCRIPTION
This changes the `--interface` and `--metrics-interface` args of resolved to take an arbitrary socket address (a string in the form `ip:port`) rather than assuming it's an IPv4 address on port 53 (for the `interface`) or on `--metrics-port` (for the `metrics-interface`).

This is a slight breaking change as it does mean the port is now requires, and the `--metrics-port` argument is no more, but I think the extra flexibility is worth it.