### PR TITLE
Add in-principle support for querying nameservers over IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ server for home networks.  To that end, it supports:
 - Hosts files
 - Zone files
 
-It does not support querying upstream nameservers over IPv6: I don't
-have IPv6 at home, so this code doesn't support it yet.
+It supports querying upstream nameservers over IPv6 in principle (if
+`--protocol-mode` is not set to `only-v4`), but this isn't really tested since I
+don't have IPv6 at home.
 
 
 Usage

--- a/lib-dns-resolver/src/util/types.rs
+++ b/lib-dns-resolver/src/util/types.rs
@@ -1,6 +1,54 @@
 use std::collections::HashSet;
+use std::fmt;
+use std::str::FromStr;
 
 use dns_types::protocol::types::*;
+
+pub const CANNOT_PARSE_PROTOCOL_MODE: &str =
+    "expected one of 'only-v4', 'prefer-v4', 'prefer-v6', 'only'v6'";
+
+/// How the recursive resolver should choose which IP address to try for
+/// upstream nameservers.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ProtocolMode {
+    /// Only use IPv4 (e.g. this is an IPv4-only network), rejecting a
+    /// nameserver if it is only available over IPv6.
+    OnlyV4,
+    /// If a nameserver is only available over IPv6, use that; but if it is
+    /// available over both IPv4 and IPv6 (or only IPv4), use the IPv4 address.
+    PreferV4,
+    /// If a nameserver is only available over IPv4, use that; but if it is
+    /// available over both IPv4 and IPv6 (or only IPv6), use the IPv6 address.
+    PreferV6,
+    /// Only use IPv6 (e.g. this is an IPv6-only network), rejecting a
+    /// nameserver if it is only available over IPv4.
+    OnlyV6,
+}
+
+impl fmt::Display for ProtocolMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ProtocolMode::OnlyV4 => write!(f, "only-v4"),
+            ProtocolMode::PreferV4 => write!(f, "prefer-v4"),
+            ProtocolMode::PreferV6 => write!(f, "prefer-v6"),
+            ProtocolMode::OnlyV6 => write!(f, "only-v6"),
+        }
+    }
+}
+
+impl FromStr for ProtocolMode {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "only-v4" => Ok(ProtocolMode::OnlyV4),
+            "prefer-v4" => Ok(ProtocolMode::PreferV4),
+            "prefer-v6" => Ok(ProtocolMode::PreferV6),
+            "only-v6" => Ok(ProtocolMode::OnlyV6),
+            _ => Err(CANNOT_PARSE_PROTOCOL_MODE),
+        }
+    }
+}
 
 /// The result of a name resolution attempt.
 ///


### PR DESCRIPTION
This adds a new flag `--protocol-mode` which takes one of four values:

- `only-v4` - only use IPv4 (e.g. this is an IPv4-only network), rejecting a nameserver if it is only available over IPv6.

- `prefer-v4` - if a nameserver is only available over IPv6, use that; but if it is available over both IPv4 and IPv6 (or only IPv4), use the IPv4 address.

- `prefer-v6` - if a nameserver is only available over IPv4, use that; but if it is available over both IPv4 and IPv6 (or only IPv6), use the IPv6 address.

- `only-v6` - only use IPv6 (e.g. this is an IPv6-only network), rejecting a nameserver if it is only available over IPv4.

I only have IPv4 at home, so this isn't really tested, but it should work.  The default is `only-v4`.

Right now resolved suffers from the problem of assuming one hostname maps to one IP address.  So if a nameserver has both A and AAAA records, and the protocol mode is set to a `prefer-*` option, but that address doesn't work, it won't try the other one.  For that matter, if there are multiple A (or AAAA) records and the first one it tries doesn't work, it won't try the others.  This hasn't caused any problems that I've noticed, but it would be nice to fix.

This commit also fixes the case where a glue AAAA record answers the query, and so can be used to avoid an additional nameserver query. Previously only glue A records were used for that.