### PR TITLE
Make the upstream DNS port configurable

### DIFF
--- a/bin-dnsq/src/main.rs
+++ b/bin-dnsq/src/main.rs
@@ -57,6 +57,11 @@ struct Args {
     #[clap(short, long, default_value_t = ProtocolMode::OnlyV4, value_parser)]
     protocol_mode: ProtocolMode,
 
+    /// Which port to query upstream nameservers over when acting as a recursive
+    /// resolver
+    #[clap(long, default_value_t = 53, value_parser)]
+    upstream_dns_port: u16,
+
     /// Act as a forwarding resolver, not a recursive resolver: forward queries
     /// which can't be answered from local state to this nameserver (in
     /// `ip:port` form)
@@ -114,6 +119,7 @@ async fn main() {
     let (_, response) = resolve(
         !args.authoritative_only,
         args.protocol_mode,
+        args.upstream_dns_port,
         args.forward_address,
         &zones,
         &SharedCache::new(),

--- a/lib-dns-resolver/src/lib.rs
+++ b/lib-dns-resolver/src/lib.rs
@@ -43,6 +43,7 @@ pub const RECURSION_LIMIT: usize = 32;
 pub async fn resolve(
     is_recursive: bool,
     protocol_mode: ProtocolMode,
+    upstream_dns_port: u16,
     forward_address: Option<SocketAddr>,
     zones: &Zones,
     cache: &SharedCache,
@@ -66,6 +67,7 @@ pub async fn resolve(
         } else {
             resolve_recursive(
                 protocol_mode,
+                upstream_dns_port,
                 &mut question_stack,
                 &mut metrics,
                 zones,


### PR DESCRIPTION
Along with now being able to specify the listening port, this allows running multiple instances of resolved on the same host, for integration testing.