### PR TITLE
Add `Context` struct for all the common resolver args

### DIFF
--- a/lib-dns-resolver/src/context.rs
+++ b/lib-dns-resolver/src/context.rs
@@ -1,0 +1,51 @@
+use dns_types::protocol::types::*;
+use dns_types::zones::types::Zones;
+
+use crate::cache::SharedCache;
+use crate::metrics::Metrics;
+
+pub struct Context<'a, CT> {
+    // global context
+    pub r: CT,
+    pub zones: &'a Zones,
+    pub cache: &'a SharedCache,
+    // request state
+    question_stack: Vec<Question>,
+    metrics: Metrics,
+}
+
+impl<'a, CT> Context<'a, CT> {
+    pub fn new(r: CT, zones: &'a Zones, cache: &'a SharedCache, recursion_limit: usize) -> Self {
+        Self {
+            r,
+            zones,
+            cache,
+            question_stack: Vec::with_capacity(recursion_limit),
+            metrics: Metrics::new(),
+        }
+    }
+
+    pub fn metrics(&mut self) -> &mut Metrics {
+        &mut self.metrics
+    }
+
+    pub fn done(self) -> Metrics {
+        self.metrics
+    }
+
+    pub fn at_recursion_limit(&self) -> bool {
+        self.question_stack.len() == self.question_stack.capacity()
+    }
+
+    pub fn is_duplicate_question(&self, question: &Question) -> bool {
+        self.question_stack.contains(question)
+    }
+
+    pub fn push_question(&mut self, question: &Question) {
+        self.question_stack.push(question.clone());
+    }
+
+    pub fn pop_question(&mut self) {
+        self.question_stack.pop();
+    }
+}

--- a/lib-dns-resolver/src/local.rs
+++ b/lib-dns-resolver/src/local.rs
@@ -763,7 +763,7 @@ mod tests {
 
         zones.insert(
             Zone::deserialise(
-                r#"
+                r"
 $ORIGIN example.com.
 
 a              300 IN A     1.1.1.1
@@ -772,14 +772,14 @@ cname-cycle-a  300 IN CNAME cname-cycle-b
 cname-cycle-b  300 IN CNAME cname-cycle-a
 delegated      300 IN NS    ns.delegated
 trailing-cname 300 IN CNAME somewhere-else
-"#,
+",
             )
             .unwrap(),
         );
 
         zones.insert(
             Zone::deserialise(
-                r#"
+                r"
 $ORIGIN authoritative.example.com.
 
 @ IN SOA mname rname 1 30 30 30 30
@@ -790,20 +790,20 @@ cname-and-a            300 IN CNAME www
 cname-authoritative    300 IN CNAME www
 cname-nonauthoritative 300 IN CNAME a.example.com.
 delegated              300 IN NS    ns.delegated
-"#,
+",
             )
             .unwrap(),
         );
 
         zones.insert(
             Zone::deserialise(
-                r#"
+                r"
 $ORIGIN authoritative-2.example.com.
 
 @ IN SOA mname rname 1 30 30 30 30
 
 cname 300 IN CNAME www.authoritative.example.com.
-"#,
+",
             )
             .unwrap(),
         );


### PR DESCRIPTION
The resolver functions were getting a bit unwieldy with their slowly-growing parameter lists that had to be passed around everywhere. So instead add a `Context` type which has everything needed to resolve a question, other than the question itself, as resolving one question might entail resolving others.