### PR TITLE
Replace uses of `Vec<u8>` with `Bytes` / `BytesMut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ name = "dns-types"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "bytes",
  "criterion",
  "rand",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +48,7 @@ name = "dns-types"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "bytes",
  "rand",
 ]
 

--- a/lib-dns-resolver/src/lib.rs
+++ b/lib-dns-resolver/src/lib.rs
@@ -1,6 +1,8 @@
 #![warn(clippy::pedantic)]
 // Sometimes a redundant else is clearer
 #![allow(clippy::redundant_else)]
+// False positives for `bytes::Bytes`
+#![allow(clippy::mutable_key_type)]
 // Don't care enough to fix
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::must_use_candidate)]

--- a/lib-dns-types/Cargo.toml
+++ b/lib-dns-types/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 arbitrary = { version = "1", features = ["derive"], optional = true }
+bytes = "1"
 rand = { version = "0.8.5", optional = true }
 
 [dev-dependencies]

--- a/lib-dns-types/src/hosts/types.rs
+++ b/lib-dns-types/src/hosts/types.rs
@@ -159,20 +159,10 @@ mod tests {
 
         let mut out = Hosts::new();
         for (k, v) in arbitrary.v4 {
-            let mut k2 = k.clone();
-            k2.labels.pop();
-            k2.octets.pop();
-            k2.labels.append(&mut apex.labels.clone());
-            k2.octets.append(&mut apex.octets.clone());
-            out.v4.insert(k2, v);
+            out.v4.insert(k.make_subdomain_of(apex).unwrap(), v);
         }
         for (k, v) in arbitrary.v6 {
-            let mut k2 = k.clone();
-            k2.labels.pop();
-            k2.octets.pop();
-            k2.labels.append(&mut apex.labels.clone());
-            k2.octets.append(&mut apex.octets.clone());
-            out.v6.insert(k2, v);
+            out.v6.insert(k.make_subdomain_of(apex).unwrap(), v);
         }
         out
     }

--- a/lib-dns-types/src/lib.rs
+++ b/lib-dns-types/src/lib.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::pedantic)]
+// False positives for `bytes::Bytes`
+#![allow(clippy::mutable_key_type)]
 // Don't care enough to fix
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::must_use_candidate)]

--- a/lib-dns-types/src/protocol/serialise.rs
+++ b/lib-dns-types/src/protocol/serialise.rs
@@ -171,14 +171,17 @@ impl ResourceRecord {
 
 impl DomainName {
     pub fn serialise(self, buffer: &mut WritableBuffer, compress: bool) {
-        if !compress {
-            buffer.memoise_name(&self);
-            buffer.write_octets(&self.octets);
-        } else if let Some(ptr) = buffer.name_pointer(&self) {
-            buffer.write_u16(ptr);
-        } else {
-            buffer.memoise_name(&self);
-            buffer.write_octets(&self.octets);
+        if compress {
+            if let Some(ptr) = buffer.name_pointer(&self) {
+                buffer.write_u16(ptr);
+                return;
+            }
+        }
+
+        buffer.memoise_name(&self);
+        for label in self.labels {
+            buffer.write_u8(label.len());
+            buffer.write_octets(&label.octets);
         }
     }
 }

--- a/lib-dns-types/src/protocol/serialise.rs
+++ b/lib-dns-types/src/protocol/serialise.rs
@@ -1,6 +1,7 @@
 //! Serialisation of DNS messages to the wire format.  See the `types`
 //! module for details of the format.
 
+use bytes::{BufMut, BytesMut};
 use std::collections::HashMap;
 
 use crate::protocol::types::*;
@@ -10,7 +11,7 @@ impl Message {
     ///
     /// If the message is invalid (the `Message` type permits more
     /// states than strictly allowed).
-    pub fn into_octets(self) -> Result<Vec<u8>, Error> {
+    pub fn into_octets(self) -> Result<BytesMut, Error> {
         let mut buffer = WritableBuffer::default();
         self.serialise(&mut buffer)?;
         Ok(buffer.octets)
@@ -231,14 +232,14 @@ impl std::error::Error for Error {
 
 /// A buffer which can be written to, for serialisation purposes.
 pub struct WritableBuffer {
-    pub octets: Vec<u8>,
+    pub octets: BytesMut,
     name_pointers: HashMap<DomainName, u16>,
 }
 
 impl Default for WritableBuffer {
     fn default() -> Self {
         Self {
-            octets: Vec::with_capacity(512),
+            octets: BytesMut::with_capacity(512),
             name_pointers: HashMap::new(),
         }
     }
@@ -264,25 +265,19 @@ impl WritableBuffer {
     }
 
     pub fn write_u8(&mut self, octet: u8) {
-        self.octets.push(octet);
+        self.octets.put_u8(octet);
     }
 
     pub fn write_u16(&mut self, value: u16) {
-        for octet in value.to_be_bytes() {
-            self.octets.push(octet);
-        }
+        self.write_octets(&value.to_be_bytes());
     }
 
     pub fn write_u32(&mut self, value: u32) {
-        for octet in value.to_be_bytes() {
-            self.octets.push(octet);
-        }
+        self.write_octets(&value.to_be_bytes());
     }
 
     pub fn write_octets(&mut self, octets: &[u8]) {
-        for octet in octets {
-            self.octets.push(*octet);
-        }
+        self.octets.put_slice(octets);
     }
 }
 

--- a/lib-dns-types/src/protocol/types.rs
+++ b/lib-dns-types/src/protocol/types.rs
@@ -1,3 +1,4 @@
+use bytes::{BufMut, Bytes, BytesMut};
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::slice::Iter;
@@ -36,6 +37,9 @@ pub const HEADER_MASK_RCODE: u8 = 0b0000_1111;
 
 /// Offset for the rcode field.
 pub const HEADER_OFFSET_RCODE: usize = 0;
+
+/// Encoded representation of the root domain (`b"\0"`).
+pub const ROOT_DOMAIN_OCTETS: &[u8] = &[0];
 
 /// Basic DNS message format, used for both queries and responses.
 ///
@@ -506,10 +510,10 @@ pub enum RecordTypeWithData {
     ///
     /// Anything at all may be in the RDATA field so long as it is
     /// 65535 octets or less.
-    NULL { octets: Vec<u8> },
+    NULL { octets: Bytes },
 
     /// This application does not interpret `WKS` records.
-    WKS { octets: Vec<u8> },
+    WKS { octets: Bytes },
 
     /// ```text
     ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
@@ -522,7 +526,7 @@ pub enum RecordTypeWithData {
     PTR { ptrdname: DomainName },
 
     /// This application does not interpret `HINFO` records.
-    HINFO { octets: Vec<u8> },
+    HINFO { octets: Bytes },
 
     /// ```text
     ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
@@ -575,7 +579,7 @@ pub enum RecordTypeWithData {
     /// ```
     ///
     /// Where `TXT-DATA` is one or more character strings.
-    TXT { octets: Vec<u8> },
+    TXT { octets: Bytes },
 
     /// ```text
     ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
@@ -623,7 +627,7 @@ pub enum RecordTypeWithData {
     /// Any other record.
     Unknown {
         tag: RecordTypeUnknown,
-        octets: Vec<u8>,
+        octets: Bytes,
     },
 }
 
@@ -663,12 +667,11 @@ impl RecordTypeWithData {
 
 #[cfg(any(feature = "test-util", test))]
 impl<'a> arbitrary::Arbitrary<'a> for RecordTypeWithData {
-    // this is pretty verbose but it feels like a better way to
-    // guarantee the max size of the `Vec<u8>`s than adding a wrapper
-    // type
+    // this is pretty verbose but it feels like a better way to guarantee the
+    // max size of the `Bytes`s than adding a wrapper type
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let len = u.int_in_range(0..=128)?;
-        let octets = Vec::from(u.bytes(len)?);
+        let octets = Bytes::copy_from_slice(u.bytes(len)?);
 
         let rtype_with_data = match u.arbitrary::<RecordType>()? {
             RecordType::A => RecordTypeWithData::A {
@@ -865,14 +868,14 @@ impl<'a> arbitrary::Arbitrary<'a> for Rcode {
 /// or shorter in total, including both length and label octets.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct DomainName {
-    pub octets: Vec<u8>,
+    pub octets: Bytes,
     pub labels: Vec<Label>,
 }
 
 impl DomainName {
     pub fn root_domain() -> Self {
         DomainName {
-            octets: vec![0],
+            octets: Bytes::from_static(ROOT_DOMAIN_OCTETS),
             labels: vec![Label::new()],
         }
     }
@@ -885,8 +888,15 @@ impl DomainName {
         self.labels.ends_with(&other.labels)
     }
 
+    pub fn make_subdomain_of(&self, origin: &Self) -> Option<Self> {
+        let mut labels = self.labels.clone();
+        labels.pop();
+        labels.append(&mut origin.labels.clone());
+        DomainName::from_labels(labels)
+    }
+
     pub fn to_dotted_string(&self) -> String {
-        if self.octets == vec![0] {
+        if self.octets == ROOT_DOMAIN_OCTETS {
             return ".".to_string();
         }
 
@@ -948,7 +958,7 @@ impl DomainName {
             return None;
         }
 
-        let mut octets = Vec::<u8>::with_capacity(DOMAINNAME_MAX_LEN);
+        let mut octets = BytesMut::with_capacity(DOMAINNAME_MAX_LEN);
         let mut blank_label = false;
 
         for label in &labels {
@@ -958,12 +968,15 @@ impl DomainName {
 
             blank_label |= label.is_empty();
 
-            octets.push(label.len());
-            octets.append(&mut label.iter().copied().collect());
+            octets.put_u8(label.len());
+            octets.put_slice(&label.octets);
         }
 
         if blank_label && octets.len() <= DOMAINNAME_MAX_LEN {
-            Some(Self { octets, labels })
+            Some(Self {
+                octets: octets.freeze(),
+                labels,
+            })
         } else {
             None
         }
@@ -1033,13 +1046,15 @@ impl<'a> arbitrary::Arbitrary<'a> for DomainName {
 pub struct Label {
     /// Private to this module so constructing an invalid `Label` is
     /// impossible.
-    octets: Vec<u8>,
+    pub octets: Bytes,
 }
 
 impl Label {
     /// Create a new, empty, label.
     pub fn new() -> Self {
-        Self { octets: Vec::new() }
+        Self {
+            octets: Bytes::new(),
+        }
     }
 
     #[allow(clippy::missing_panics_doc)]
@@ -1071,12 +1086,9 @@ impl TryFrom<&[u8]> for Label {
             return Err(LabelTryFromOctetsError::TooLong);
         }
 
-        let mut octets = Vec::with_capacity(mixed_case_octets.len());
-        for o in mixed_case_octets {
-            octets.push(o.to_ascii_lowercase());
-        }
-
-        Ok(Self { octets })
+        Ok(Self {
+            octets: Bytes::copy_from_slice(&mixed_case_octets.to_ascii_lowercase()),
+        })
     }
 }
 
@@ -1085,11 +1097,11 @@ impl<'a> arbitrary::Arbitrary<'a> for Label {
     // only generates non-empty labels
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Label> {
         let label_len = u.int_in_range::<u8>(1..=20)?;
-        let mut octets = Vec::with_capacity(label_len.into());
+        let mut octets = BytesMut::with_capacity(label_len.into());
         let bs = u.bytes(label_len.into())?;
         for b in bs {
             let ascii_byte = if b.is_ascii() { *b } else { *b % 128 };
-            octets.push(
+            octets.put_u8(
                 if ascii_byte == b'.'
                     || ascii_byte == b'*'
                     || ascii_byte == b'@'
@@ -1102,7 +1114,9 @@ impl<'a> arbitrary::Arbitrary<'a> for Label {
                 },
             );
         }
-        Ok(Self { octets })
+        Ok(Self {
+            octets: octets.freeze(),
+        })
     }
 }
 
@@ -1649,6 +1663,16 @@ mod tests {
     }
 
     #[test]
+    fn make_subdomain_is_subdomain() {
+        let sub = domain("foo.");
+        let apex = domain("bar.");
+        let combined = sub.make_subdomain_of(&apex);
+
+        assert_eq!(Some(domain("foo.bar.")), combined);
+        assert!(combined.unwrap().is_subdomain_of(&apex));
+    }
+
+    #[test]
     fn domainname_conversions() {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
@@ -1666,7 +1690,7 @@ mod tests {
                     output.push('.');
                 }
 
-                let mut octets = Vec::with_capacity(label_len);
+                let mut octets = BytesMut::with_capacity(label_len);
                 for _ in 0..label_len {
                     let mut chr = rng.gen_range(32..126);
 
@@ -1679,11 +1703,11 @@ mod tests {
                         chr = b'X';
                     }
 
-                    octets.push(chr);
+                    octets.put_u8(chr);
                     dotted_string_input.push(chr as char);
                     output.push(chr.to_ascii_lowercase() as char);
                 }
-                labels_input.push(octets.as_slice().try_into().unwrap());
+                labels_input.push(Label::try_from(&octets.freeze()[..]).unwrap());
             }
 
             labels_input.push(Label::new());
@@ -1719,12 +1743,12 @@ pub mod test_util {
     pub fn arbitrary_resourcerecord() -> ResourceRecord {
         let mut rng = rand::thread_rng();
         for size in [128, 256, 512, 1024, 2048, 4096] {
-            let mut buf = Vec::new();
+            let mut buf = BytesMut::with_capacity(size);
             for _ in 0..size {
-                buf.push(rng.gen());
+                buf.put_u8(rng.gen());
             }
 
-            if let Ok(rr) = ResourceRecord::arbitrary(&mut Unstructured::new(&buf)) {
+            if let Ok(rr) = ResourceRecord::arbitrary(&mut Unstructured::new(&buf.freeze())) {
                 return rr;
             }
         }
@@ -1781,7 +1805,7 @@ pub mod test_util {
             name: domain(name),
             rtype_with_data: RecordTypeWithData::Unknown {
                 tag: RecordTypeUnknown(100),
-                octets: octets.into(),
+                octets: Bytes::copy_from_slice(octets),
             },
             rclass: RecordClass::IN,
             ttl: 300,

--- a/lib-dns-types/src/zones/serialise.rs
+++ b/lib-dns-types/src/zones/serialise.rs
@@ -101,11 +101,10 @@ impl Zone {
             } else if name == apex {
                 "@".to_string()
             } else {
-                let octets_to_keep = name.octets.len() - apex.octets.len();
                 let labels_to_keep = name.labels.len() - apex.labels.len();
                 DomainName {
-                    octets: Bytes::copy_from_slice(&name.octets[..octets_to_keep]),
                     labels: Vec::from(&name.labels[..labels_to_keep]),
+                    len: name.len - apex.len,
                 }
                 .to_dotted_string()
             }

--- a/lib-dns-types/src/zones/serialise.rs
+++ b/lib-dns-types/src/zones/serialise.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::collections::HashSet;
 use std::fmt::Write as _;
 
@@ -15,7 +16,7 @@ impl Zone {
                     .get_apex()
                     .to_dotted_string()
                     .bytes()
-                    .collect::<Vec<u8>>(),
+                    .collect::<Bytes>(),
                 false,
             );
 
@@ -100,18 +101,17 @@ impl Zone {
             } else if name == apex {
                 "@".to_string()
             } else {
-                let mut stripped = name.clone();
-                for _ in 0..apex.labels.len() {
-                    stripped.labels.pop();
+                let octets_to_keep = name.octets.len() - apex.octets.len();
+                let labels_to_keep = name.labels.len() - apex.labels.len();
+                DomainName {
+                    octets: Bytes::copy_from_slice(&name.octets[..octets_to_keep]),
+                    labels: Vec::from(&name.labels[..labels_to_keep]),
                 }
-                for _ in 0..apex.octets.len() {
-                    stripped.octets.pop();
-                }
-                stripped.to_dotted_string()
+                .to_dotted_string()
             }
         };
 
-        serialise_octets(&domain_str.bytes().collect::<Vec<u8>>(), false)
+        serialise_octets(&domain_str.bytes().collect::<Bytes>(), false)
     }
 
     /// Serialise the RDATA, with domains displayed relative to the apex (if

--- a/lib-dns-types/src/zones/types.rs
+++ b/lib-dns-types/src/zones/types.rs
@@ -816,7 +816,7 @@ mod tests {
             let mut zone = Zone::new(domain("example.com."), None);
             let mut rr = arbitrary_resourcerecord();
             rr.rclass = RecordClass::IN;
-            make_subdomain(&zone.apex, &mut rr.name);
+            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
 
             zone.insert(&rr.name, rr.rtype_with_data.clone(), rr.ttl);
 
@@ -838,13 +838,11 @@ mod tests {
             let mut zone = Zone::new(domain("example.com."), None);
             let mut rr = arbitrary_resourcerecord();
             rr.rclass = RecordClass::IN;
-            make_subdomain(&zone.apex, &mut rr.name);
+            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
 
             zone.insert_wildcard(&rr.name, rr.rtype_with_data.clone(), rr.ttl);
 
-            let mut subdomain = domain("foo.");
-            make_subdomain(&rr.name, &mut subdomain);
-            rr.name = subdomain;
+            rr.name = domain("foo.").make_subdomain_of(&rr.name).unwrap();
 
             let expected = Some(ZoneResult::Answer {
                 rrs: vec![rr.clone()],
@@ -865,7 +863,7 @@ mod tests {
         for _ in 0..expected.capacity() {
             let mut rr = arbitrary_resourcerecord();
             rr.rclass = RecordClass::IN;
-            make_subdomain(&zone.apex, &mut rr.name);
+            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
             expected.push(rr.clone());
             zone.insert(&rr.name, rr.rtype_with_data, rr.ttl);
         }
@@ -890,7 +888,7 @@ mod tests {
         for _ in 0..expected.capacity() {
             let mut rr = arbitrary_resourcerecord();
             rr.rclass = RecordClass::IN;
-            make_subdomain(&zone.apex, &mut rr.name);
+            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
             expected.push(rr.clone());
             zone.insert_wildcard(&rr.name, rr.rtype_with_data, rr.ttl);
         }
@@ -1089,12 +1087,5 @@ mod tests {
             Some(ZoneResult::Answer { rrs: Vec::new() }),
             zone.resolve(&domain("example.com."), QueryType::Wildcard)
         );
-    }
-
-    fn make_subdomain(apex: &DomainName, domain: &mut DomainName) {
-        domain.labels.pop();
-        domain.octets.pop();
-        domain.labels.append(&mut apex.labels.clone());
-        domain.octets.append(&mut apex.octets.clone());
     }
 }


### PR DESCRIPTION
This is potentially more efficient and, as multiple `Bytes` values can refer to the same underlying memory, could unlock improvements to the protocol deserialisation logic in the future (eg, having `Label`s refer directly to the original network packet rather than being immediately copied).

Also removes `DomainName.octets`, which eliminates some copying in the deserialiser and roughly halves the memory usage of each `DomainName`.