### PR TITLE
Add `AAAA` records to localhost zone

### DIFF
--- a/config/zones/localhost.zone
+++ b/config/zones/localhost.zone
@@ -4,5 +4,7 @@ $ORIGIN localhost.
 
 @ IN SOA . . 1 3600 3600 3600 3600
 
-@ IN A 127.0.0.1
-* IN A 127.0.0.1
+@ IN A    127.0.0.1
+@ IN AAAA ::1
+* IN A    127.0.0.1
+* IN AAAA ::1


### PR DESCRIPTION
RFC 6761 specifies that it should resolve for IPv6 queries.