### PR TITLE
Allow `clippy::needless_lifetimes`

### DIFF
--- a/crates/dns-resolver/src/lib.rs
+++ b/crates/dns-resolver/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(clippy::redundant_else)]
 // False positives for `bytes::Bytes`
 #![allow(clippy::mutable_key_type)]
+// I think explicit lifetimes make it easier to read in some cases
+#![allow(clippy::needless_lifetimes)]
 // Don't care enough to fix
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::must_use_candidate)]

--- a/crates/resolved/src/main.rs
+++ b/crates/resolved/src/main.rs
@@ -158,7 +158,7 @@ async fn resolve_and_build_response(args: ListenArgs, query: Message) -> Message
     response
 }
 
-async fn handle_raw_message<'a>(args: ListenArgs, buf: &[u8]) -> Option<Message> {
+async fn handle_raw_message(args: ListenArgs, buf: &[u8]) -> Option<Message> {
     let res = Message::from_octets(buf);
     tracing::debug!(message = ?res, "got message");
 


### PR DESCRIPTION
I disagree that this a problem:

```
error: the following explicit lifetimes could be elided: 'a
  --> crates/dns-resolver/src/forwarding.rs:32:33
   |
32 | pub async fn resolve_forwarding<'a>(
   |                                 ^^
33 |     context: &mut ForwardingContext<'a>,
   |                                     ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
```

The alternative would be to remove the lifetime parameter from the function and use the anonymous lifetime in `ForwardingContext<'_>` but I don't like that.