### PR TITLE
Fix bug with cache next expiry time

### DIFF
--- a/crates/dns-resolver/src/cache.rs
+++ b/crates/dns-resolver/src/cache.rs
@@ -368,35 +368,21 @@ impl<K1: Clone + Eq + Hash, K2: Copy + Eq + Hash, V: PartialEq> PartitionedCache
         let expiry = now + ttl;
         let tuple = (value, expiry);
         if let Some(partition) = self.partitions.get_mut(&partition_key) {
+            let mut recalculate_next_expiry = false;
+
             if let Some(tuples) = partition.records.get_mut(&record_key) {
-                let mut duplicate_expires_at = None;
                 for i in 0..tuples.len() {
                     let t = &tuples[i];
                     if t.0 == tuple.0 {
-                        duplicate_expires_at = Some(t.1);
+                        partition.size -= 1;
+                        self.current_size -= 1;
+                        recalculate_next_expiry = t.1 == partition.next_expiry;
                         tuples.swap_remove(i);
                         break;
                     }
                 }
 
                 tuples.push(tuple);
-
-                if let Some(dup_expiry) = duplicate_expires_at {
-                    partition.size -= 1;
-                    self.current_size -= 1;
-
-                    if dup_expiry == partition.next_expiry {
-                        let mut new_next_expiry = expiry;
-                        for (_, e) in tuples {
-                            if *e < new_next_expiry {
-                                new_next_expiry = *e;
-                            }
-                        }
-                        partition.next_expiry = new_next_expiry;
-                        self.expiry_priority
-                            .change_priority(&partition_key, Reverse(partition.next_expiry));
-                    }
-                }
             } else {
                 partition.records.insert(record_key, vec![tuple]);
             }
@@ -406,6 +392,19 @@ impl<K1: Clone + Eq + Hash, K2: Copy + Eq + Hash, V: PartialEq> PartitionedCache
                 .change_priority(&partition_key, Reverse(partition.last_read));
             if expiry < partition.next_expiry {
                 partition.next_expiry = expiry;
+                self.expiry_priority
+                    .change_priority(&partition_key, Reverse(partition.next_expiry));
+            } else if recalculate_next_expiry {
+                // the next record to expire was popped so we need to examine
+                // all current records to determine the new next expiry
+                partition.next_expiry = expiry;
+                for tuples in partition.records.values() {
+                    for (_, expires) in tuples {
+                        if *expires < partition.next_expiry {
+                            partition.next_expiry = *expires;
+                        }
+                    }
+                }
                 self.expiry_priority
                     .change_priority(&partition_key, Reverse(partition.next_expiry));
             }

--- a/crates/dns-resolver/src/local.rs
+++ b/crates/dns-resolver/src/local.rs
@@ -376,7 +376,6 @@ pub struct AuthoritativeNameError {
 #[cfg(test)]
 mod tests {
     use dns_types::protocol::types::test_util::*;
-    use dns_types::zones::types::*;
     use std::net::Ipv4Addr;
 
     use super::*;


### PR DESCRIPTION
This bug was found by fuzzing (fuzz tests to follow in a separate PR after further refactoring).

If we insert a sequence of three RRs for the same domain into the cache like so:

1. Record Type 1, TTL very soon
2. Record Type 2, TTL less soon
3. Record Type 1, TTL even later

Then the `next_expiry` of the partition would be set to `even later`, because when RR 3 is inserted, it replaces RR 1.  RR 1 is the next record to expire, so this triggers an update of `next_expiry`.  But the update was performed by only looking at other RRs of the same type, meaning it would return the expiry of RR 3 and not RR 2.

This wouldn't have made anything go *wrong*, expired records are filtered out of the cache result (as we can't assume expiry runs promptly), but it may have led to holding expired records in memory for longer than needed.