### PR TITLE
Move arbitrary unit tests into fuzz tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,9 +66,34 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
-      - name: Run fuzz tests
-        run: |
-          set -ex
-          for target in $(cargo fuzz list); do
-            cargo fuzz run $target -- -max_total_time=30s
-          done
+      - parallel:
+        - name: Fuzz (cache_prune_expires_all)
+          run: cargo fuzz run cache_prune_expires_all -- -max_total_time=90s
+        - name: Fuzz (cache_put_can_get)
+          run: cargo fuzz run cache_put_can_get -- -max_total_time=90s
+        - name: Fuzz (cache_put_deduplicates_and_maintains_invariants)
+          run: cargo fuzz run cache_put_deduplicates_and_maintains_invariants -- -max_total_time=90s
+        - name: Fuzz (cache_put_maintains_invariants)
+          run: cargo fuzz run cache_put_maintains_invariants -- -max_total_time=90s
+        - name: Fuzz (cache_put_then_expire_maintains_invariants)
+          run: cargo fuzz run cache_put_then_expire_maintains_invariants -- -max_total_time=90s
+        - name: Fuzz (cache_put_then_get_maintains_invariants)
+          run: cargo fuzz run cache_put_then_get_maintains_invariants -- -max_total_time=90s
+        - name: Fuzz (domainname_conversions)
+          run: cargo fuzz run domainname_conversions -- -max_total_time=90s
+        - name: Fuzz (hosts_deserialise_round_trip)
+          run: cargo fuzz run hosts_deserialise_round_trip -- -max_total_time=90s
+        - name: Fuzz (hosts_merge_zone_merge_equiv_when_disjoint)
+          run: cargo fuzz run hosts_merge_zone_merge_equiv_when_disjoint -- -max_total_time=90s
+        - name: Fuzz (hosts_serialise_round_trip)
+          run: cargo fuzz run hosts_serialise_round_trip -- -max_total_time=90s
+        - name: Fuzz (hosts_zone_round_trip)
+          run: cargo fuzz run hosts_zone_round_trip -- -max_total_time=90s
+        - name: Fuzz (wire_deserialise_round_trip)
+          run: cargo fuzz run wire_deserialise_round_trip -- -max_total_time=90s
+        - name: Fuzz (wire_serialise_round_trip)
+          run: cargo fuzz run wire_serialise_round_trip -- -max_total_time=90s
+        - name: Fuzz (zone_deserialise_round_trip)
+          run: cargo fuzz run zone_deserialise_round_trip -- -max_total_time=90s
+        - name: Fuzz (zone_serialise_round_trip)
+          run: cargo fuzz run zone_serialise_round_trip -- -max_total_time=90s

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,6 @@ dependencies = [
  "arbitrary",
  "bytes",
  "criterion",
- "rand",
 ]
 
 [[package]]

--- a/crates/dns-resolver/Cargo.toml
+++ b/crates/dns-resolver/Cargo.toml
@@ -16,4 +16,3 @@ tracing = "0.1.44"
 
 [dev-dependencies]
 criterion = "0.8.2"
-dns-types = { path = "../dns-types", features = ["test-util"] }

--- a/crates/dns-resolver/src/cache.rs
+++ b/crates/dns-resolver/src/cache.rs
@@ -537,140 +537,43 @@ impl<K1: Clone + Eq + Hash, K2: Copy + Eq + Hash, V: PartialEq> PartitionedCache
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use dns_types::protocol::types::test_util::*;
-
-    use super::test_util::*;
+#[allow(clippy::missing_panics_doc)]
+pub mod test_util {
     use super::*;
 
-    #[test]
-    fn cache_put_can_get() {
-        for _ in 0..100 {
-            let mut cache = Cache::new();
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            cache.insert(&rr);
+    /// Assert that the cache response has exactly one element and
+    /// that it matches the original (all fields equal except TTL,
+    /// where the original is >=).
+    pub fn assert_cache_response(original: &ResourceRecord, response: &[ResourceRecord]) {
+        assert_eq!(1, response.len());
+        let cached = response[0].clone();
 
-            assert_cache_response(
-                &rr,
-                &cache.get_without_checking_expiration(
-                    &rr.name,
-                    QueryType::Record(rr.rtype_with_data.rtype()),
-                ),
-            );
-            assert_cache_response(
-                &rr,
-                &cache.get_without_checking_expiration(&rr.name, QueryType::Wildcard),
-            );
+        assert_eq!(original.name, cached.name);
+        assert_eq!(original.rtype_with_data, cached.rtype_with_data);
+        assert_eq!(RecordClass::IN, cached.rclass);
+        assert!(original.ttl >= cached.ttl);
+    }
+
+    /// Assert that the cache has a given number of records.
+    pub fn assert_current_size(expected: usize, cache: &Cache) {
+        if expected != cache.inner.current_size {
+            dbg!(&cache.inner.partitions);
+            assert_eq!(expected, cache.inner.current_size);
         }
     }
 
-    #[test]
-    fn cache_put_deduplicates_and_maintains_invariants() {
-        let mut cache = Cache::new();
-        let mut rr = arbitrary_resourcerecord();
-        rr.rclass = RecordClass::IN;
-
-        cache.insert(&rr);
-        cache.insert(&rr);
-
-        assert_eq!(1, cache.inner.current_size);
-        assert_invariants(&cache);
+    /// Expire stale records and assert the count expired.
+    pub fn assert_expires(expected: usize, cache: &mut Cache) {
+        assert_eq!(expected, cache.inner.remove_expired());
     }
 
-    #[test]
-    fn cache_put_maintains_invariants() {
-        let mut cache = Cache::new();
-
-        for _ in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            cache.insert(&rr);
-        }
-
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_then_get_maintains_invariants() {
-        let mut cache = Cache::new();
-        let mut queries = Vec::new();
-
-        for _ in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            cache.insert(&rr);
-            queries.push((
-                rr.name.clone(),
-                QueryType::Record(rr.rtype_with_data.rtype()),
-            ));
-        }
-        for (name, qtype) in queries {
-            cache.get_without_checking_expiration(&name, qtype);
-        }
-
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_then_prune_maintains_invariants() {
-        let mut cache = Cache::with_desired_size(25);
-
-        for _ in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.ttl = 300; // this case isn't testing expiration
-            cache.insert(&rr);
-        }
-
-        // might be more than 75 because the size is measured in
-        // records, but pruning is done on whole domains
-        let (overflow, current_size, expired, pruned) = cache.prune();
-        assert!(overflow);
-        assert_eq!(0, expired);
-        assert!(pruned >= 75);
-        assert!(cache.inner.current_size <= 25);
-        assert_eq!(cache.inner.current_size, current_size);
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_put_then_expire_maintains_invariants() {
-        let mut cache = Cache::new();
-
-        for i in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.ttl = if i > 0 && i % 2 == 0 { 0 } else { 300 };
-            cache.insert(&rr);
-        }
-
-        assert_eq!(49, cache.inner.remove_expired());
-        assert_eq!(51, cache.inner.current_size);
-        assert_invariants(&cache);
-    }
-
-    #[test]
-    fn cache_prune_expires_all() {
-        let mut cache = Cache::with_desired_size(99);
-
-        for i in 0..100 {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.ttl = if i > 0 && i % 2 == 0 { 0 } else { 300 };
-            cache.insert(&rr);
-        }
-
-        let (overflow, current_size, expired, pruned) = cache.prune();
-        assert!(overflow);
-        assert_eq!(49, expired);
-        assert_eq!(0, pruned);
-        assert_eq!(cache.inner.current_size, current_size);
-        assert_invariants(&cache);
-    }
-
-    fn assert_invariants(cache: &Cache) {
+    /// Assert that the cache invariants are met:
+    ///
+    /// - `current_size` is the number of records
+    /// - `next_expiry` of each partition is the min of its expiry times
+    /// - `access_priority` has all the partitions in the correct order
+    /// - `expiry_priority` has all the partitions in the correct order
+    pub fn assert_invariants(cache: &Cache) {
         assert_eq!(
             cache.inner.current_size,
             cache
@@ -722,24 +625,5 @@ mod tests {
 
         assert_eq!(cache.inner.access_priority, access_priority);
         assert_eq!(cache.inner.expiry_priority, expiry_priority);
-    }
-}
-
-#[cfg(test)]
-#[allow(clippy::missing_panics_doc)]
-pub mod test_util {
-    use super::*;
-
-    /// Assert that the cache response has exactly one element and
-    /// that it matches the original (all fields equal except TTL,
-    /// where the original is >=).
-    pub fn assert_cache_response(original: &ResourceRecord, response: &[ResourceRecord]) {
-        assert_eq!(1, response.len());
-        let cached = response[0].clone();
-
-        assert_eq!(original.name, cached.name);
-        assert_eq!(original.rtype_with_data, cached.rtype_with_data);
-        assert_eq!(RecordClass::IN, cached.rclass);
-        assert!(original.ttl >= cached.ttl);
     }
 }

--- a/crates/dns-types/Cargo.toml
+++ b/crates/dns-types/Cargo.toml
@@ -8,12 +8,9 @@ edition = "2021"
 [dependencies]
 arbitrary = { version = "1", features = ["derive"], optional = true }
 bytes = "1"
-rand = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
-arbitrary = { version = "1", features = ["derive"] }
 criterion = "0.8.2"
-rand = "0.9.4"
 
 [features]
-test-util = ["arbitrary", "rand"]
+fuzz = ["dep:arbitrary"]

--- a/crates/dns-types/src/hosts/types.rs
+++ b/crates/dns-types/src/hosts/types.rs
@@ -9,7 +9,7 @@ pub const TTL: u32 = 5;
 
 /// A collection of A records.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Hosts {
     pub v4: HashMap<DomainName, Ipv4Addr>,
     pub v6: HashMap<DomainName, Ipv6Addr>,
@@ -115,80 +115,4 @@ impl TryFrom<Zone> for Hosts {
 pub enum TryFromZoneError {
     HasWildcardRecords,
     HasRecordTypesOtherThanA,
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::protocol::types::test_util::*;
-
-    use super::test_util::*;
-    use super::*;
-
-    #[test]
-    fn hosts_zone_roundtrip() {
-        for _ in 0..100 {
-            let expected = arbitrary_hosts();
-            if let Ok(actual) = Hosts::try_from(Zone::from(expected.clone())) {
-                assert_eq!(expected, actual);
-            } else {
-                panic!("expected round-trip");
-            }
-        }
-    }
-
-    #[test]
-    fn hosts_merge_zone_merge_equiv_when_disjoint() {
-        for _ in 0..100 {
-            let hosts1 = arbitrary_hosts_with_apex(&domain("hosts1."));
-            let hosts2 = arbitrary_hosts_with_apex(&domain("hosts2."));
-
-            let mut combined_hosts = hosts1.clone();
-            combined_hosts.merge(hosts2.clone());
-
-            let combined_zone_direct = Zone::from(combined_hosts.clone());
-            let mut combined_zone_indirect = Zone::from(hosts1);
-            combined_zone_indirect.merge(hosts2.into()).unwrap();
-
-            assert_eq!(combined_zone_direct, combined_zone_indirect);
-            assert_eq!(Ok(combined_hosts), combined_zone_direct.try_into());
-        }
-    }
-
-    fn arbitrary_hosts_with_apex(apex: &DomainName) -> Hosts {
-        let arbitrary = arbitrary_hosts();
-
-        let mut out = Hosts::new();
-        for (k, v) in arbitrary.v4 {
-            out.v4.insert(k.make_subdomain_of(apex).unwrap(), v);
-        }
-        for (k, v) in arbitrary.v6 {
-            out.v6.insert(k.make_subdomain_of(apex).unwrap(), v);
-        }
-        out
-    }
-}
-
-#[cfg(any(feature = "test-util", test))]
-#[allow(clippy::missing_panics_doc)]
-pub mod test_util {
-    use super::*;
-
-    use arbitrary::{Arbitrary, Unstructured};
-    use rand::Rng;
-
-    pub fn arbitrary_hosts() -> Hosts {
-        let mut rng = rand::rng();
-        for size in [128, 256, 512, 1024, 2048, 4096] {
-            let mut buf = Vec::new();
-            for _ in 0..size {
-                buf.push(rng.random());
-            }
-
-            if let Ok(rr) = Hosts::arbitrary(&mut Unstructured::new(&buf)) {
-                return rr;
-            }
-        }
-
-        panic!("could not generate arbitrary value!");
-    }
 }

--- a/crates/dns-types/src/protocol/types.rs
+++ b/crates/dns-types/src/protocol/types.rs
@@ -1,7 +1,10 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::Bytes;
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
+
+#[cfg(feature = "fuzz")]
+use bytes::{BufMut, BytesMut};
 
 /// Maximum encoded length of a domain name.  The number of labels
 /// plus sum of the lengths of the labels.
@@ -55,7 +58,7 @@ pub const HEADER_OFFSET_RCODE: usize = 0;
 ///
 /// See section 4.1 of RFC 1035.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Message {
     pub header: Header,
     pub questions: Vec<Question>,
@@ -149,7 +152,7 @@ impl Message {
 /// type, as they are only used during serialisation and deserialisation and can
 /// be inferred from the other `Message` fields.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Header {
     /// A 16 bit identifier assigned by the program that generates any
     /// kind of query.  This identifier is copied the corresponding
@@ -248,7 +251,7 @@ pub struct Header {
 ///
 /// See section 4.1.2 of RFC 1035.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Question {
     /// a domain name represented as a sequence of labels, where each
     /// label consists of a length octet followed by that number of
@@ -315,7 +318,7 @@ impl fmt::Display for Question {
 ///
 /// See section 4.1.3 of RFC 1035.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ResourceRecord {
     /// a domain name to which this resource record pertains.
     pub name: DomainName,
@@ -660,7 +663,7 @@ impl RecordTypeWithData {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for RecordTypeWithData {
     // this is pretty verbose but it feels like a better way to guarantee the
     // max size of the `Bytes`s than adding a wrapper type
@@ -774,7 +777,7 @@ impl From<Opcode> for u8 {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for Opcode {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.arbitrary::<u8>()?))
@@ -846,7 +849,7 @@ impl From<Rcode> for u8 {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for Rcode {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.arbitrary::<u8>()?))
@@ -1015,7 +1018,7 @@ impl std::error::Error for DomainNameFromStr {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for DomainName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let num_labels = u.int_in_range::<usize>(0..=10)?;
@@ -1080,7 +1083,7 @@ impl TryFrom<&[u8]> for Label {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for Label {
     // only generates non-empty labels
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Label> {
@@ -1183,7 +1186,7 @@ impl From<QueryType> for u16 {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for QueryType {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.arbitrary::<u16>()?))
@@ -1244,7 +1247,7 @@ impl From<QueryClass> for u16 {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for QueryClass {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.arbitrary::<u16>()?))
@@ -1432,7 +1435,7 @@ impl From<RecordType> for u16 {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for RecordType {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.arbitrary::<u16>()?))
@@ -1534,7 +1537,7 @@ impl From<RecordClass> for u16 {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for RecordClass {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.arbitrary::<u16>()?))
@@ -1543,8 +1546,6 @@ impl<'a> arbitrary::Arbitrary<'a> for RecordClass {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
-
     use super::test_util::*;
     use super::*;
 
@@ -1659,90 +1660,11 @@ mod tests {
         assert_eq!(Some(domain("foo.bar.")), combined);
         assert!(combined.unwrap().is_subdomain_of(&apex));
     }
-
-    #[test]
-    fn domainname_conversions() {
-        let mut rng = rand::rng();
-        for _ in 0..100 {
-            let labels_len = rng.random_range(0..5);
-
-            let mut dotted_string_input = String::new();
-            let mut labels_input = Vec::with_capacity(labels_len);
-            let mut output = String::new();
-
-            for i in 0..labels_len {
-                let label_len = rng.random_range(1..10);
-
-                if i > 0 {
-                    dotted_string_input.push('.');
-                    output.push('.');
-                }
-
-                let mut octets = BytesMut::with_capacity(label_len);
-                for _ in 0..label_len {
-                    let mut chr = rng.random_range(32..126);
-
-                    if chr == b'.'
-                        || chr == b'*'
-                        || chr == b'@'
-                        || chr == b'#'
-                        || (chr as char).is_whitespace()
-                    {
-                        chr = b'X';
-                    }
-
-                    octets.put_u8(chr);
-                    dotted_string_input.push(chr as char);
-                    output.push(chr.to_ascii_lowercase() as char);
-                }
-                labels_input.push(Label::try_from(&octets.freeze()[..]).unwrap());
-            }
-
-            labels_input.push(Label::new());
-            dotted_string_input.push('.');
-            output.push('.');
-
-            assert_eq!(
-                Some(output.clone()),
-                DomainName::from_dotted_string(&dotted_string_input).map(|d| d.to_dotted_string())
-            );
-
-            assert_eq!(
-                Some(output),
-                DomainName::from_labels(labels_input.clone()).map(|d| d.to_dotted_string())
-            );
-
-            assert_eq!(
-                DomainName::from_dotted_string(&dotted_string_input).map(|d| d.to_dotted_string()),
-                DomainName::from_labels(labels_input).map(|d| d.to_dotted_string())
-            );
-        }
-    }
 }
 
-#[cfg(any(feature = "test-util", test))]
 #[allow(clippy::missing_panics_doc)]
 pub mod test_util {
     use super::*;
-
-    use arbitrary::{Arbitrary, Unstructured};
-    use rand::Rng;
-
-    pub fn arbitrary_resourcerecord() -> ResourceRecord {
-        let mut rng = rand::rng();
-        for size in [128, 256, 512, 1024, 2048, 4096] {
-            let mut buf = BytesMut::with_capacity(size);
-            for _ in 0..size {
-                buf.put_u8(rng.random());
-            }
-
-            if let Ok(rr) = ResourceRecord::arbitrary(&mut Unstructured::new(&buf.freeze())) {
-                return rr;
-            }
-        }
-
-        panic!("could not generate arbitrary value!");
-    }
 
     pub fn domain(name: &str) -> DomainName {
         DomainName::from_dotted_string(name).unwrap()

--- a/crates/dns-types/src/zones/types.rs
+++ b/crates/dns-types/src/zones/types.rs
@@ -105,7 +105,7 @@ impl Default for Zone {
     }
 }
 
-#[cfg(any(feature = "test-util", test))]
+#[cfg(feature = "fuzz")]
 impl<'a> arbitrary::Arbitrary<'a> for Zone {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut zone = if u.arbitrary()? {
@@ -517,7 +517,7 @@ impl ZoneRecords {
 
 /// A SOA record.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "test-util", test), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct SOA {
     pub mname: DomainName,
     pub rname: DomainName,
@@ -659,7 +659,7 @@ fn merge_zrs_helper(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
     use crate::protocol::types::test_util::*;
@@ -809,64 +809,61 @@ mod tests {
 
     #[test]
     fn zone_insert_resolve() {
-        for _ in 0..100 {
-            let mut zone = Zone::new(domain("example.com."), None);
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
+        let mut zone = Zone::new(domain("example.com."), None);
+        let rr1 = a_record("www.example.com.", Ipv4Addr::new(1, 1, 1, 1));
+        let rr2 = aaaa_record("www.example.com.", Ipv6Addr::LOCALHOST);
 
-            zone.insert(&rr.name, rr.rtype_with_data.clone(), rr.ttl);
+        zone.insert(&rr1.name, rr1.rtype_with_data.clone(), rr1.ttl);
+        zone.insert(&rr2.name, rr2.rtype_with_data.clone(), rr2.ttl);
 
-            let expected = Some(ZoneResult::Answer {
-                rrs: vec![rr.clone()],
-            });
-
-            assert_eq!(
-                expected,
-                zone.resolve(&rr.name, QueryType::Record(rr.rtype_with_data.rtype()))
-            );
-            assert_eq!(expected, zone.resolve(&rr.name, QueryType::Wildcard));
-        }
+        assert_eq!(
+            Some(ZoneResult::Answer {
+                rrs: vec![rr1.clone()]
+            }),
+            zone.resolve(&rr1.name, QueryType::Record(rr1.rtype_with_data.rtype()))
+        );
+        assert_eq!(
+            Some(ZoneResult::Answer {
+                rrs: vec![rr2.clone()]
+            }),
+            zone.resolve(&rr2.name, QueryType::Record(rr2.rtype_with_data.rtype()))
+        );
     }
 
     #[test]
     fn zone_insert_wildcard_resolve() {
-        for _ in 0..100 {
-            let mut zone = Zone::new(domain("example.com."), None);
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
+        let mut zone = Zone::new(domain("example.com."), None);
+        let rr1 = a_record("www.example.com.", Ipv4Addr::new(1, 1, 1, 1));
+        let rr2 = aaaa_record("www.example.com.", Ipv6Addr::LOCALHOST);
 
-            zone.insert_wildcard(&rr.name, rr.rtype_with_data.clone(), rr.ttl);
+        zone.insert(&rr1.name, rr1.rtype_with_data.clone(), rr1.ttl);
+        zone.insert(&rr2.name, rr2.rtype_with_data.clone(), rr2.ttl);
 
-            rr.name = domain("foo.").make_subdomain_of(&rr.name).unwrap();
+        let mut expected = vec![rr1.clone(), rr2.clone()];
+        expected.sort();
 
-            let expected = Some(ZoneResult::Answer {
-                rrs: vec![rr.clone()],
-            });
+        if let Some(ZoneResult::Answer { mut rrs }) = zone.resolve(&rr1.name, QueryType::Wildcard) {
+            rrs.sort();
 
-            assert_eq!(
-                expected,
-                zone.resolve(&rr.name, QueryType::Record(rr.rtype_with_data.rtype()))
-            );
-            assert_eq!(expected, zone.resolve(&rr.name, QueryType::Wildcard));
+            assert_eq!(expected, rrs);
+        } else {
+            panic!("no result");
         }
     }
 
     #[test]
     fn zone_insert_all_records() {
         let mut zone = Zone::new(domain("example.com."), None);
-        let mut expected = Vec::with_capacity(100);
-        for _ in 0..expected.capacity() {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
+
+        let mut expected = Vec::new();
+        for i in 0..10 {
+            let rr = a_record(&format!("foo-{i}.example.com."), Ipv4Addr::new(1, 1, 1, 1));
             expected.push(rr.clone());
             zone.insert(&rr.name, rr.rtype_with_data, rr.ttl);
         }
         expected.sort();
 
-        let mut actual = Vec::with_capacity(expected.capacity());
+        let mut actual = Vec::new();
         for (name, zrs) in &zone.all_records() {
             for zr in zrs {
                 actual.push(zr.to_rr(name));
@@ -881,11 +878,10 @@ mod tests {
     #[test]
     fn zone_insert_all_wildcard_records() {
         let mut zone = Zone::new(domain("example.com."), None);
-        let mut expected = Vec::with_capacity(100);
-        for _ in 0..expected.capacity() {
-            let mut rr = arbitrary_resourcerecord();
-            rr.rclass = RecordClass::IN;
-            rr.name = rr.name.make_subdomain_of(&zone.apex).unwrap();
+
+        let mut expected = Vec::new();
+        for i in 0..10 {
+            let rr = a_record(&format!("foo-{i}.example.com."), Ipv4Addr::new(1, 1, 1, 1));
             expected.push(rr.clone());
             zone.insert_wildcard(&rr.name, rr.rtype_with_data, rr.ttl);
         }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,12 +3,53 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -54,7 +95,20 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "dns-resolver"
+version = "0.1.0"
+dependencies = [
+ "async-recursion",
+ "bytes",
+ "dns-types",
+ "priority-queue",
+ "rand",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -63,8 +117,13 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bytes",
- "rand",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "getrandom"
@@ -74,8 +133,41 @@ checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.13.3+wasi-0.2.2",
  "windows-targets",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -104,12 +196,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -164,8 +314,45 @@ dependencies = [
 name = "resolved-fuzz"
 version = "0.0.0"
 dependencies = [
+ "bytes",
+ "dns-resolver",
  "dns-types",
  "libfuzzer-sys",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -173,6 +360,22 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "syn"
@@ -186,10 +389,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -198,6 +466,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -300,7 +592,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -311,5 +603,5 @@ checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,11 +10,15 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+bytes = "1"
 libfuzzer-sys = "0.4"
+
+[dependencies.dns-resolver]
+path = "../crates/dns-resolver"
 
 [dependencies.dns-types]
 path = "../crates/dns-types"
-features = ["test-util"]
+features = ["fuzz"]
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -55,3 +59,66 @@ name = "hosts_serialise_round_trip"
 path = "fuzz_targets/hosts_serialise_round_trip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "hosts_zone_round_trip"
+path = "fuzz_targets/hosts_zone_round_trip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "hosts_merge_zone_merge_equiv_when_disjoint"
+path = "fuzz_targets/hosts_merge_zone_merge_equiv_when_disjoint.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cache_put_can_get"
+path = "fuzz_targets/cache_put_can_get.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cache_put_deduplicates_and_maintains_invariants"
+path = "fuzz_targets/cache_put_deduplicates_and_maintains_invariants.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cache_put_maintains_invariants"
+path = "fuzz_targets/cache_put_maintains_invariants.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cache_put_then_get_maintains_invariants"
+path = "fuzz_targets/cache_put_then_get_maintains_invariants.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cache_put_then_expire_maintains_invariants"
+path = "fuzz_targets/cache_put_then_expire_maintains_invariants.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "cache_prune_expires_all"
+path = "fuzz_targets/cache_prune_expires_all.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "domainname_conversions"
+path = "fuzz_targets/domainname_conversions.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/cache_prune_expires_all.rs
+++ b/fuzz/fuzz_targets/cache_prune_expires_all.rs
@@ -1,0 +1,41 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use dns_resolver::cache::Cache;
+use dns_resolver::cache::test_util::{assert_current_size, assert_invariants};
+use dns_types::protocol::types::{ResourceRecord, RecordClass};
+use dns_types::protocol::types::test_util::domain;
+
+const DESIRED: usize = 25;
+
+fuzz_target!(|rrs: Vec<(ResourceRecord, bool)>| {
+    let mut cache = Cache::with_desired_size(DESIRED);
+
+    let mut expected_expired: usize = 0;
+    let mut num_records: usize = 0;
+    
+    for (rr, expire) in rrs {
+        num_records += 1;
+        let mut rr = rr.clone();
+        // ensure each record has a unique name
+        rr.name = rr.name.make_subdomain_of(&domain(&format!("{}.", num_records))).unwrap();
+        rr.rclass = RecordClass::IN;
+        if expire {
+            rr.ttl = 0;
+            expected_expired += 1;
+        } else {
+            rr.ttl = 300;
+        }
+        cache.insert(&rr);
+    }
+
+    // if expiry isn't enough, records must be pruned to fit the desired size
+    let expected_pruned = (num_records - expected_expired).saturating_sub(DESIRED);
+
+    let (overflow, current_size, expired, pruned) = cache.prune();
+    assert_eq!(overflow, num_records > DESIRED);
+    assert_eq!(expected_expired, expired);
+    assert_eq!(expected_pruned, pruned);
+    assert_current_size(current_size, &cache);
+    assert_invariants(&cache);
+});

--- a/fuzz/fuzz_targets/cache_put_can_get.rs
+++ b/fuzz/fuzz_targets/cache_put_can_get.rs
@@ -1,0 +1,25 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use dns_resolver::cache::Cache;
+use dns_resolver::cache::test_util::assert_cache_response;
+use dns_types::protocol::types::{ResourceRecord, RecordClass, QueryType};
+
+fuzz_target!(|rr: ResourceRecord| {
+    let mut cache = Cache::new();
+    let mut rr = rr.clone();
+    rr.rclass = RecordClass::IN;
+    cache.insert(&rr);
+
+    assert_cache_response(
+        &rr,
+        &cache.get_without_checking_expiration(
+            &rr.name,
+            QueryType::Record(rr.rtype_with_data.rtype()),
+        ),
+    );
+    assert_cache_response(
+        &rr,
+        &cache.get_without_checking_expiration(&rr.name, QueryType::Wildcard),
+    );
+});

--- a/fuzz/fuzz_targets/cache_put_deduplicates_and_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_deduplicates_and_maintains_invariants.rs
@@ -1,0 +1,18 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use dns_resolver::cache::Cache;
+use dns_resolver::cache::test_util::{assert_current_size, assert_invariants};
+use dns_types::protocol::types::{ResourceRecord, RecordClass};
+
+fuzz_target!(|rr: ResourceRecord| {
+    let mut cache = Cache::new();
+    let mut rr = rr.clone();
+    rr.rclass = RecordClass::IN;
+
+    cache.insert(&rr);
+    cache.insert(&rr);
+
+    assert_current_size(1, &cache);
+    assert_invariants(&cache);
+});

--- a/fuzz/fuzz_targets/cache_put_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_maintains_invariants.rs
@@ -1,0 +1,18 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use dns_resolver::cache::Cache;
+use dns_resolver::cache::test_util::assert_invariants;
+use dns_types::protocol::types::{ResourceRecord, RecordClass};
+
+fuzz_target!(|rrs: Vec<ResourceRecord>| {
+    let mut cache = Cache::new();
+
+    for rr in rrs {
+        let mut rr = rr.clone();
+        rr.rclass = RecordClass::IN;
+        cache.insert(&rr);
+    }
+
+    assert_invariants(&cache);
+});

--- a/fuzz/fuzz_targets/cache_put_then_expire_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_then_expire_maintains_invariants.rs
@@ -1,0 +1,35 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use dns_resolver::cache::Cache;
+use dns_resolver::cache::test_util::{assert_current_size, assert_expires, assert_invariants};
+use dns_types::protocol::types::{ResourceRecord, RecordClass};
+use dns_types::protocol::types::test_util::domain;
+
+fuzz_target!(|rrs: Vec<(ResourceRecord, bool)>| {
+    let mut cache = Cache::new();
+
+    let mut expected_expired = 0;
+    let mut expected_kept = 0;
+    let mut i = 0;
+    
+    for (rr, expire) in rrs {
+        let mut rr = rr.clone();
+        // ensure each record has a unique name
+        rr.name = rr.name.make_subdomain_of(&domain(&format!("{}.", i))).unwrap();
+        rr.rclass = RecordClass::IN;
+        if expire {
+            rr.ttl = 0;
+            expected_expired += 1;
+        } else {
+            rr.ttl = 300;
+            expected_kept += 1;
+        }
+        cache.insert(&rr);
+        i += 1;
+    }
+
+    assert_expires(expected_expired, &mut cache);
+    assert_current_size(expected_kept, &cache);
+    assert_invariants(&cache);
+});

--- a/fuzz/fuzz_targets/cache_put_then_get_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_then_get_maintains_invariants.rs
@@ -1,0 +1,26 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use dns_resolver::cache::Cache;
+use dns_resolver::cache::test_util::assert_invariants;
+use dns_types::protocol::types::{ResourceRecord, RecordClass, QueryType};
+
+fuzz_target!(|rrs: Vec<ResourceRecord>| {
+    let mut cache = Cache::new();
+    let mut queries = Vec::new();
+
+    for rr in rrs {
+        let mut rr = rr.clone();
+        rr.rclass = RecordClass::IN;
+        cache.insert(&rr);
+        queries.push((
+            rr.name.clone(),
+            QueryType::Record(rr.rtype_with_data.rtype()),
+        ));
+    }
+    for (name, qtype) in queries {
+        cache.get_without_checking_expiration(&name, qtype);
+    }
+
+    assert_invariants(&cache);
+});

--- a/fuzz/fuzz_targets/domainname_conversions.rs
+++ b/fuzz/fuzz_targets/domainname_conversions.rs
@@ -1,0 +1,85 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use bytes::{BufMut, BytesMut};
+use std::convert::TryFrom;
+
+use dns_types::protocol::types::{DOMAINNAME_MAX_LEN, LABEL_MAX_LEN, DomainName, Label};
+
+fn to_label_chr(octet: u8) -> u8 {
+    // clamp it to the range [48, 122]
+    let chr = octet % (123 - 48) + 48;
+    if (chr >= 58 && chr <= 64) || (chr >= 91 && chr <= 96) {
+        b'X'
+    } else {
+        chr
+    }
+}
+
+fuzz_target!(|labels: Vec<Vec<u8>>| {
+    let mut dotted_string_input = String::new();
+    let mut labels_input = Vec::new();
+    let mut output = String::new();
+
+    let mut first_label = true;
+    let mut len = 0;
+    for label in labels {
+        // if we're at the start of a new label we need at least 3 octets spare:
+        // 1 octet label length + 1 octet label + 1 octet end marker; if we have
+        // less space than that, we can't fit in a new label before the end
+        if len >= DOMAINNAME_MAX_LEN - 3 {
+            break;
+        }
+
+        len += 1;
+
+        if first_label {
+            first_label = false;
+        } else {
+            dotted_string_input.push('.');
+            output.push('.');
+        }
+
+        let mut octets = BytesMut::new();
+        if label.len() == 0 {
+            let chr = b'A';
+            octets.put_u8(chr);
+            dotted_string_input.push(chr as char);
+            output.push(chr.to_ascii_lowercase() as char);
+            len += 1;
+        } else {
+            for octet in label {
+                let chr = to_label_chr(octet);
+                octets.put_u8(chr);
+                dotted_string_input.push(chr as char);
+                output.push(chr.to_ascii_lowercase() as char);
+                len += 1;
+                if octets.len() == LABEL_MAX_LEN || len == DOMAINNAME_MAX_LEN - 1 {
+                    break;
+                }
+            }
+        }
+        labels_input.push(Label::try_from(&octets.freeze()[..]).unwrap());
+    }
+
+    labels_input.push(Label::new());
+    dotted_string_input.push('.');
+    output.push('.');
+
+    if let Some(from_dotted_string) = DomainName::from_dotted_string(&dotted_string_input) {
+        assert_eq!(output.clone(), from_dotted_string.to_dotted_string());
+    } else {
+        panic!("from_dotted_string failed: {}", &dotted_string_input);
+    }
+
+    if let Some(from_labels) = DomainName::from_labels(labels_input.clone()) {
+        assert_eq!(output.clone(), from_labels.to_dotted_string());
+    } else {
+        panic!("from_labels failed");
+    }
+
+    assert_eq!(
+        DomainName::from_dotted_string(&dotted_string_input).map(|d| d.to_dotted_string()),
+        DomainName::from_labels(labels_input).map(|d| d.to_dotted_string())
+    );
+});

--- a/fuzz/fuzz_targets/hosts_merge_zone_merge_equiv_when_disjoint.rs
+++ b/fuzz/fuzz_targets/hosts_merge_zone_merge_equiv_when_disjoint.rs
@@ -1,0 +1,35 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use std::convert::TryInto;
+
+use dns_types::hosts::types::Hosts;
+use dns_types::protocol::types::DomainName;
+use dns_types::protocol::types::test_util::domain;
+use dns_types::zones::types::Zone;
+
+fn hosts_with_apex(arbitrary: Hosts, apex: DomainName) -> Hosts {
+    let mut out = Hosts::new();
+    for (k, v) in arbitrary.v4 {
+        out.v4.insert(k.make_subdomain_of(&apex).unwrap(), v);
+    }
+    for (k, v) in arbitrary.v6 {
+        out.v6.insert(k.make_subdomain_of(&apex).unwrap(), v);
+    }
+    out
+}
+
+fuzz_target!(|hosts: (Hosts, Hosts)| {
+    let disjoint_hosts1 = hosts_with_apex(hosts.0, domain("hosts1."));
+    let disjoint_hosts2 = hosts_with_apex(hosts.1, domain("hosts2."));
+
+    let mut combined_hosts = disjoint_hosts1.clone();
+    combined_hosts.merge(disjoint_hosts2.clone());
+
+    let combined_zone_direct = Zone::from(combined_hosts.clone());
+    let mut combined_zone_indirect = Zone::from(disjoint_hosts1);
+    combined_zone_indirect.merge(disjoint_hosts2.into()).unwrap();
+
+    assert_eq!(combined_zone_direct, combined_zone_indirect);
+    assert_eq!(Ok(combined_hosts), combined_zone_direct.try_into());
+});

--- a/fuzz/fuzz_targets/hosts_zone_round_trip.rs
+++ b/fuzz/fuzz_targets/hosts_zone_round_trip.rs
@@ -1,0 +1,15 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use std::convert::TryFrom;
+
+use dns_types::hosts::types::Hosts;
+use dns_types::zones::types::Zone;
+
+fuzz_target!(|hosts: Hosts| {
+    if let Ok(actual) = Hosts::try_from(Zone::from(hosts.clone())) {
+        assert_eq!(hosts, actual);
+    } else {
+        panic!("expected round-trip");
+    }
+});


### PR DESCRIPTION
These are significantly more effective at finding bugs as fuzz tests due to the coverage guidance.  Introduce parallelism in CI to avoid massively slowing down the build while also running each test for longer.

Bugs found: cf303eb75a4351d9a0b2b3359f4b3cdb4b49d212