### PR TITLE
Make cache clone very explicit

### DIFF
--- a/crates/dns-resolver/src/cache.rs
+++ b/crates/dns-resolver/src/cache.rs
@@ -81,7 +81,7 @@ impl SharedCache {
     /// # Panics
     ///
     /// If the mutex has been poisoned.
-    pub fn insert(&self, record: &ResourceRecord) {
+    pub fn insert(&self, record: ResourceRecord) {
         if record.ttl > 0 {
             let mut cache = self.cache.lock().expect(MUTEX_POISON_MESSAGE);
             cache.insert(record);
@@ -100,7 +100,7 @@ impl SharedCache {
     /// # Panics
     ///
     /// If the mutex has been poisoned.
-    pub fn insert_all(&self, records: &[ResourceRecord]) {
+    pub fn insert_all(&self, records: Vec<ResourceRecord>) {
         let mut cache = self.cache.lock().expect(MUTEX_POISON_MESSAGE);
         for record in records {
             if record.ttl > 0 {
@@ -202,11 +202,11 @@ impl Cache {
     }
 
     /// Insert an RR into the cache.
-    pub fn insert(&mut self, record: &ResourceRecord) {
+    pub fn insert(&mut self, record: ResourceRecord) {
         self.inner.upsert(
-            record.name.clone(),
+            record.name,
             record.rtype_with_data.rtype(),
-            record.rtype_with_data.clone(),
+            record.rtype_with_data,
             Duration::from_secs(record.ttl.into()),
         );
     }

--- a/crates/dns-resolver/src/forwarding.rs
+++ b/crates/dns-resolver/src/forwarding.rs
@@ -113,7 +113,7 @@ async fn resolve_forwarding_notimeout<'a>(
         // Propagate SOA RR for NXDOMAIN / NODATA responses
         let soa_rr = get_nxdomain_nodata_soa(question, &response, 0).cloned();
         let rrs = response.answers;
-        context.cache.insert_all(&rrs);
+        context.cache.insert_all(rrs.clone());
         prioritising_merge(&mut combined_rrs, rrs);
         Ok(ResolvedRecord::NonAuthoritative {
             rrs: combined_rrs,

--- a/crates/dns-resolver/src/local.rs
+++ b/crates/dns-resolver/src/local.rs
@@ -413,7 +413,7 @@ mod tests {
         let rr = a_record("cached.example.com.", Ipv4Addr::new(1, 1, 1, 1));
 
         let cache = SharedCache::new();
-        cache.insert(&rr);
+        cache.insert(rr.clone());
 
         if let Ok(LocalResolutionResult::Partial { rrs }) =
             test_resolve_local_with_cache("cached.example.com.", &cache, QueryType::Wildcard)
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn resolve_local_prefers_authoritative_zones() {
         let cache = SharedCache::new();
-        cache.insert(&a_record(
+        cache.insert(a_record(
             "www.authoritative.example.com.",
             Ipv4Addr::new(8, 8, 8, 8),
         ));
@@ -491,7 +491,7 @@ mod tests {
         let cache_rr = cname_record("a.example.com.", "b.example.com.");
 
         let cache = SharedCache::new();
-        cache.insert(&cache_rr);
+        cache.insert(cache_rr.clone());
 
         if let Ok(LocalResolutionResult::Partial { rrs }) =
             test_resolve_local_with_cache("a.example.com.", &cache, QueryType::Wildcard)
@@ -510,7 +510,7 @@ mod tests {
         let cache_rr = a_record("a.example.com.", Ipv4Addr::new(8, 8, 8, 8));
 
         let cache = SharedCache::new();
-        cache.insert(&cache_rr);
+        cache.insert(cache_rr);
 
         assert_eq!(
             test_resolve_local("a.example.com.", QueryType::Wildcard),
@@ -547,8 +547,8 @@ mod tests {
         let a_rr = a_record("a.example.com.", Ipv4Addr::new(1, 1, 1, 1));
 
         let cache = SharedCache::new();
-        cache.insert(&cname_rr1);
-        cache.insert(&cname_rr2);
+        cache.insert(cname_rr1.clone());
+        cache.insert(cname_rr2.clone());
 
         if let Ok(LocalResolutionResult::Done {
             resolved: ResolvedRecord::NonAuthoritative { rrs, soa_rr: None },

--- a/crates/dns-resolver/src/recursive.rs
+++ b/crates/dns-resolver/src/recursive.rs
@@ -186,7 +186,7 @@ async fn resolve_with_nameserver_response<'a>(
     match nameserver_response {
         NameserverResponse::Answer { rrs, soa_rr, .. } => {
             tracing::trace!("got recursive answer");
-            context.cache.insert_all(&rrs);
+            context.cache.insert_all(rrs.clone());
             prioritising_merge(&mut combined_rrs, rrs);
             Ok(Ok(ResolvedRecord::NonAuthoritative {
                 rrs: combined_rrs,
@@ -196,7 +196,7 @@ async fn resolve_with_nameserver_response<'a>(
         NameserverResponse::Delegation {
             rrs, delegation, ..
         } => {
-            context.cache.insert_all(&rrs);
+            context.cache.insert_all(rrs.clone());
             if question.qtype == QueryType::Record(RecordType::A) {
                 if let Some(rr) = get_record(&rrs, &question.name, RecordType::A) {
                     tracing::trace!("got recursive delegation - using glue A record");
@@ -221,7 +221,7 @@ async fn resolve_with_nameserver_response<'a>(
         }
         NameserverResponse::CNAME { rrs, cname, .. } => {
             tracing::trace!("got recursive CNAME");
-            context.cache.insert_all(&rrs);
+            context.cache.insert_all(rrs.clone());
             prioritising_merge(&mut combined_rrs, rrs);
             let cname_question = Question {
                 name: cname,
@@ -1215,8 +1215,8 @@ mod tests {
         let cache = SharedCache::new();
 
         for name in names {
-            cache.insert(&ns_record(name, "ns1.example.com."));
-            cache.insert(&ns_record(name, "ns2.example.com."));
+            cache.insert(ns_record(name, "ns1.example.com."));
+            cache.insert(ns_record(name, "ns2.example.com."));
         }
 
         cache

--- a/fuzz/fuzz_targets/cache_prune_expires_all.rs
+++ b/fuzz/fuzz_targets/cache_prune_expires_all.rs
@@ -26,7 +26,7 @@ fuzz_target!(|rrs: Vec<(ResourceRecord, bool)>| {
         } else {
             rr.ttl = 300;
         }
-        cache.insert(&rr);
+        cache.insert(rr);
     }
 
     // if expiry isn't enough, records must be pruned to fit the desired size

--- a/fuzz/fuzz_targets/cache_put_can_get.rs
+++ b/fuzz/fuzz_targets/cache_put_can_get.rs
@@ -9,7 +9,7 @@ fuzz_target!(|rr: ResourceRecord| {
     let mut cache = Cache::new();
     let mut rr = rr.clone();
     rr.rclass = RecordClass::IN;
-    cache.insert(&rr);
+    cache.insert(rr.clone());
 
     assert_cache_response(
         &rr,

--- a/fuzz/fuzz_targets/cache_put_deduplicates_and_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_deduplicates_and_maintains_invariants.rs
@@ -10,8 +10,8 @@ fuzz_target!(|rr: ResourceRecord| {
     let mut rr = rr.clone();
     rr.rclass = RecordClass::IN;
 
-    cache.insert(&rr);
-    cache.insert(&rr);
+    cache.insert(rr.clone());
+    cache.insert(rr);
 
     assert_current_size(1, &cache);
     assert_invariants(&cache);

--- a/fuzz/fuzz_targets/cache_put_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_maintains_invariants.rs
@@ -8,10 +8,9 @@ use dns_types::protocol::types::{ResourceRecord, RecordClass};
 fuzz_target!(|rrs: Vec<ResourceRecord>| {
     let mut cache = Cache::new();
 
-    for rr in rrs {
-        let mut rr = rr.clone();
+    for mut rr in rrs {
         rr.rclass = RecordClass::IN;
-        cache.insert(&rr);
+        cache.insert(rr);
     }
 
     assert_invariants(&cache);

--- a/fuzz/fuzz_targets/cache_put_then_expire_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_then_expire_maintains_invariants.rs
@@ -13,8 +13,7 @@ fuzz_target!(|rrs: Vec<(ResourceRecord, bool)>| {
     let mut expected_kept = 0;
     let mut i = 0;
     
-    for (rr, expire) in rrs {
-        let mut rr = rr.clone();
+    for (mut rr, expire) in rrs {
         // ensure each record has a unique name
         rr.name = rr.name.make_subdomain_of(&domain(&format!("{}.", i))).unwrap();
         rr.rclass = RecordClass::IN;
@@ -25,7 +24,7 @@ fuzz_target!(|rrs: Vec<(ResourceRecord, bool)>| {
             rr.ttl = 300;
             expected_kept += 1;
         }
-        cache.insert(&rr);
+        cache.insert(rr);
         i += 1;
     }
 

--- a/fuzz/fuzz_targets/cache_put_then_get_maintains_invariants.rs
+++ b/fuzz/fuzz_targets/cache_put_then_get_maintains_invariants.rs
@@ -9,14 +9,13 @@ fuzz_target!(|rrs: Vec<ResourceRecord>| {
     let mut cache = Cache::new();
     let mut queries = Vec::new();
 
-    for rr in rrs {
-        let mut rr = rr.clone();
+    for mut rr in rrs {
         rr.rclass = RecordClass::IN;
-        cache.insert(&rr);
         queries.push((
             rr.name.clone(),
             QueryType::Record(rr.rtype_with_data.rtype()),
         ));
+        cache.insert(rr);
     }
     for (name, qtype) in queries {
         cache.get_without_checking_expiration(&name, qtype);


### PR DESCRIPTION
Previously `Cache.insert` took a ref, but it clones the name and data. Make it take ownership, so the cloning is clear outside this method.